### PR TITLE
fix(planner/docker): Return the actual content

### DIFF
--- a/internal/dockerfile/dockerfile.go
+++ b/internal/dockerfile/dockerfile.go
@@ -5,11 +5,9 @@ import (
 	"github.com/zeabur/zbpack/pkg/types"
 )
 
-const dockerfileKey = "dockerfile"
-
 // GenerateDockerfile generates the Dockerfile for static files.
 func GenerateDockerfile(meta types.PlanMeta) (string, error) {
-	return meta[dockerfileKey], nil
+	return meta["content"], nil
 }
 
 type pack struct {

--- a/internal/dockerfile/dockerfile_test.go
+++ b/internal/dockerfile/dockerfile_test.go
@@ -1,0 +1,22 @@
+package dockerfile
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateDockerFile(t *testing.T) {
+	const expectedContent = "FROM alpine"
+
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "Dockerfile", []byte(expectedContent), 0o644)
+
+	ctx := GetMeta(GetMetaOptions{Src: fs})
+	packer := NewPacker()
+	actualContent, err := packer.GenerateDockerfile(ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedContent, actualContent)
+}

--- a/internal/dockerfile/plan.go
+++ b/internal/dockerfile/plan.go
@@ -60,7 +60,11 @@ func ReadDockerfile(ctx *dockerfilePlanContext) ([]byte, error) {
 		return []byte(content), nil
 	}
 
-	content, err := afero.ReadFile(ctx.src, "Dockerfile")
+	dockerfileName, err := FindDockerfile(ctx)
+	if err != nil {
+		return nil, err
+	}
+	content, err := afero.ReadFile(ctx.src, dockerfileName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dockerfile/plan.go
+++ b/internal/dockerfile/plan.go
@@ -3,6 +3,7 @@ package dockerfile
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"log"
 	"strconv"
@@ -17,8 +18,9 @@ import (
 type dockerfilePlanContext struct {
 	src afero.Fs
 
-	dockerfileName optional.Option[string]
-	ExposePort     optional.Option[string]
+	dockerfileName    optional.Option[string]
+	dockerfileContent optional.Option[[]byte]
+	ExposePort        optional.Option[string]
 }
 
 // GetMetaOptions is the options for GetMeta.
@@ -50,13 +52,21 @@ func FindDockerfile(ctx *dockerfilePlanContext) (string, error) {
 	return "", errors.New("no dockerfile in this environment")
 }
 
-func openDockerfile(ctx *dockerfilePlanContext) (afero.File, error) {
-	dockerfileName, err := FindDockerfile(ctx)
+// ReadDockerfile reads the Dockerfile in the project.
+func ReadDockerfile(ctx *dockerfilePlanContext) ([]byte, error) {
+	c := &ctx.dockerfileContent
+
+	if content, err := c.Take(); err == nil {
+		return []byte(content), nil
+	}
+
+	content, err := afero.ReadFile(ctx.src, "Dockerfile")
 	if err != nil {
 		return nil, err
 	}
 
-	return ctx.src.Open(dockerfileName)
+	*c = optional.Some(content)
+	return content, nil
 }
 
 // GetExposePort gets the exposed port of the Dockerfile project.
@@ -64,19 +74,15 @@ func GetExposePort(ctx *dockerfilePlanContext) string {
 	const defaultValue = "8080"
 	const exposePrefix = "EXPOSE "
 	ctxPort := &ctx.ExposePort
-	dockerFile, err := openDockerfile(ctx)
+	dockerFile, err := ReadDockerfile(ctx)
 	if err != nil {
 		return defaultValue
 	}
-	defer func() {
-		if err := dockerFile.Close(); err != nil {
-			log.Println(err)
-		}
-	}()
 
-	buf := bufio.NewScanner(dockerFile)
-	for buf.Scan() {
-		line := strings.ToUpper(buf.Text())
+	reader := bytes.NewReader(dockerFile)
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := strings.ToUpper(scanner.Text())
 
 		port, found := strings.CutPrefix(line, exposePrefix)
 		if !found {
@@ -98,16 +104,18 @@ func GetExposePort(ctx *dockerfilePlanContext) string {
 func GetMeta(opt GetMetaOptions) types.PlanMeta {
 	ctx := new(dockerfilePlanContext)
 	ctx.src = opt.Src
-	dockerfileName, err := FindDockerfile(ctx)
+
+	dockerfileContent, err := ReadDockerfile(ctx)
 	if err != nil {
 		log.Println(err)
-		dockerfileName = "" // no Dockerfile
+		dockerfileContent = []byte{} // no Dockerfile
 	}
+
 	exposePort := GetExposePort(ctx)
 
 	meta := types.PlanMeta{
-		"expose":      exposePort,
-		dockerfileKey: dockerfileName,
+		"expose":  exposePort,
+		"content": string(dockerfileContent),
 	}
 	return meta
 }

--- a/internal/dockerfile/plan_test.go
+++ b/internal/dockerfile/plan_test.go
@@ -93,3 +93,12 @@ func TestGetExposePort_WithLowercaseDockerfileSpecified(t *testing.T) {
 
 	assert.Equal(t, "1145", port)
 }
+
+func TestGetMeta_Content(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine"), 0o644)
+
+	meta := GetMeta(GetMetaOptions{Src: fs})
+
+	assert.Equal(t, "FROM alpine", meta["content"])
+}


### PR DESCRIPTION
This issue was produced in da9e8122ace0247cd9f6d5266f2ba61a3be2e78d.
It returns the “filename” rather than the actual content,
so we get the “Dockerfile” instead of the content of “Dockerfile”
when calling `GenerateDockerfile()`.
