### PR TITLE
feat(cli): Print usage information in the terminal

### DIFF
--- a/cmd/zbpack/main.go
+++ b/cmd/zbpack/main.go
@@ -12,10 +12,12 @@ import (
 )
 
 func main() {
-	path := ""
-	if len(os.Args) > 1 {
-		path = os.Args[1]
+	if len(os.Args) < 2 {
+		println("Usage: zbpack <directory to analyse or build>")
+		os.Exit(0)
 	}
+
+	path := os.Args[1]
 
 	trueValue := true
 


### PR DESCRIPTION
## Feature description
Print a simple usage text to the terminal when zbpack is run without any arguments

## Solution description
Check for the number of arguments and if its less than 2, the command will not execute and exit the program. This provides a better experience for the user. To run zbpack in the current dir, you can do `zbpack  .`

Closes #60 