### PR TITLE
[Draft] feat(planner): Add .NET support

### DIFF
--- a/internal/dotnet/dotnet.go
+++ b/internal/dotnet/dotnet.go
@@ -1,0 +1,52 @@
+// Package dotnet is the planner of Dotnet projects.
+package dotnet
+
+import (
+	"github.com/zeabur/zbpack/pkg/packer"
+	"github.com/zeabur/zbpack/pkg/types"
+)
+
+// GenerateDockerfile generates the Dockerfile for Dotnet projects.
+func GenerateDockerfile(meta types.PlanMeta) (string, error) {
+	sdkVer := meta["sdk"]
+	entryPoint := meta["entryPoint"]
+	dockerfile := `
+		# https://hub.docker.com/_/microsoft-dotnet
+		FROM mcr.microsoft.com/dotnet/sdk:` + sdkVer + ` AS build
+		WORKDIR /source
+		
+		# copy csproj and restore as distinct layers
+		COPY *.csproj ./
+		RUN dotnet restore
+		
+		# copy everything else and build app
+		COPY . ./
+		WORKDIR /source
+		RUN dotnet publish -c release -o /app
+		
+		# final stage/image
+		FROM mcr.microsoft.com/dotnet/aspnet:` + sdkVer + `
+		WORKDIR /app
+		COPY --from=build /app ./
+		ENTRYPOINT ["dotnet", "` + entryPoint + `.dll"]	
+	`
+
+	return dockerfile, nil
+}
+
+type pack struct {
+	*identify
+}
+
+// NewPacker returns a new Dotnet packer.
+func NewPacker() packer.Packer {
+	return &pack{
+		identify: &identify{},
+	}
+}
+
+func (p *pack) GenerateDockerfile(meta types.PlanMeta) (string, error) {
+	return GenerateDockerfile(meta)
+}
+
+var _ packer.Packer = (*pack)(nil)

--- a/internal/dotnet/dotnet_test.go
+++ b/internal/dotnet/dotnet_test.go
@@ -1,0 +1,49 @@
+package dotnet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/zbpack/pkg/types"
+)
+
+func TestGenerateDockerFile_Valid(t *testing.T) {
+	planMeta := types.PlanMeta{
+		"sdk":        "7.0",
+		"entryPoint": "dotnetapp",
+	}
+
+	dockerfile, err := GenerateDockerfile(planMeta)
+	assert.Empty(t, err)
+
+	tests := []struct {
+		s        string
+		expected bool
+	}{
+		{
+			s:        "",
+			expected: false,
+		},
+		{
+			s:        "sdk:7.0",
+			expected: true,
+		},
+		{
+			s:        "dotnetapp.dll",
+			expected: true,
+		},
+	}
+
+	contains := func(dockerfile, s string) bool {
+		if s == "" {
+			return false
+		}
+
+		return strings.Contains(dockerfile, s)
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, contains(dockerfile, test.s), test.expected)
+	}
+}

--- a/internal/dotnet/identify_test.go
+++ b/internal/dotnet/identify_test.go
@@ -1,0 +1,69 @@
+package dotnet
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/zbpack/pkg/plan"
+)
+
+func TestMatch_NotFound(t *testing.T) {
+	identifier := NewIdentifier()
+
+	fs := afero.NewMemMapFs()
+
+	assert.False(t, identifier.Match(fs))
+}
+
+func TestMatch_Found(t *testing.T) {
+	path := "../../tests/dotnet-samples/dotnetapp/"
+	assert.DirExists(t, path)
+
+	fs := afero.NewBasePathFs(afero.NewOsFs(), path)
+
+	identifier := NewIdentifier()
+	assert.True(t, identifier.Match(fs))
+}
+
+func TestPlanMeta_NotFound(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	options := plan.NewPlannerOptions{
+		Source:        fs,
+		SubmoduleName: "",
+	}
+
+	var err error
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+
+	identifier := NewIdentifier()
+	identifier.PlanMeta(options)
+
+	if err != nil {
+		t.Errorf("Expected panic with message 'Unable to determine SDK version', got %v", err)
+	}
+}
+
+func TestPlanMeta_Found(t *testing.T) {
+	path := "../../tests/dotnet-samples/dotnetapp/"
+	assert.DirExists(t, path)
+
+	fs := afero.NewBasePathFs(afero.NewOsFs(), path)
+
+	options := plan.NewPlannerOptions{
+		Source:        fs,
+		SubmoduleName: "dotnetapp",
+	}
+
+	identifier := NewIdentifier()
+	planMeta := identifier.PlanMeta(options)
+
+	assert.NotEmpty(t, planMeta)
+	assert.Equal(t, planMeta["sdk"], "7.0")
+	assert.Equal(t, planMeta["entryPoint"], "dotnetapp")
+}

--- a/internal/dotnet/plan.go
+++ b/internal/dotnet/plan.go
@@ -1,0 +1,30 @@
+package dotnet
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/afero"
+	"github.com/zeabur/zbpack/internal/utils"
+)
+
+// DetermineSDKVersion returns the version of the SDK.
+func DetermineSDKVersion(entryPoint string, src afero.Fs) (string, error) {
+	fileName := entryPoint + ".csproj"
+	if utils.HasFile(src, fileName) {
+		content, err := afero.ReadFile(src, fileName)
+		if err != nil {
+			return "", err
+		}
+
+		pattern := regexp.MustCompile(`<TargetFramework>([^<]+)</TargetFramework>`)
+		// Search for the target framework in the file.
+		matches := pattern.FindStringSubmatch(string(content))
+		if len(matches) > 1 {
+			return strings.Replace(matches[1], "net", "", -1), nil
+		}
+	}
+
+	return "", errors.New("Unable to determine SDK version")
+}

--- a/internal/dotnet/plan_test.go
+++ b/internal/dotnet/plan_test.go
@@ -1,0 +1,27 @@
+package dotnet
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineSDKVersion_EmptyEntryPoint(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	ver, err := DetermineSDKVersion("", fs)
+	assert.ErrorContains(t, err, "Unable to determine SDK version")
+	assert.Empty(t, ver)
+}
+
+func TestDetermineSDKVersion_Valid(t *testing.T) {
+	path := "../../tests/dotnet-samples/dotnetapp/"
+	assert.DirExists(t, path)
+
+	fs := afero.NewBasePathFs(afero.NewOsFs(), path)
+
+	ver, err := DetermineSDKVersion("dotnetapp", fs)
+	assert.NoError(t, err)
+	assert.Equal(t, ver, "7.0")
+}

--- a/pkg/types/plan.go
+++ b/pkg/types/plan.go
@@ -20,6 +20,7 @@ const (
 	PlanTypeJava   PlanType = "java"
 	PlanTypeDeno   PlanType = "deno"
 	PlanTypeRust   PlanType = "rust"
+	PlanTypeDotnet PlanType = "dotnet"
 	PlanTypeStatic PlanType = "static"
 )
 

--- a/pkg/zeaburpack/identifiers.go
+++ b/pkg/zeaburpack/identifiers.go
@@ -3,6 +3,7 @@ package zeaburpack
 import (
 	"github.com/zeabur/zbpack/internal/deno"
 	dockerfilePkg "github.com/zeabur/zbpack/internal/dockerfile"
+	"github.com/zeabur/zbpack/internal/dotnet"
 	"github.com/zeabur/zbpack/internal/golang"
 	"github.com/zeabur/zbpack/internal/java"
 	"github.com/zeabur/zbpack/internal/nodejs"
@@ -27,6 +28,7 @@ func SupportedIdentifiers() []plan.Identifier {
 		java.NewIdentifier(),
 		deno.NewIdentifier(),
 		rust.NewIdentifier(),
+		dotnet.NewIdentifier(),
 		static.NewIdentifier(),
 	}
 }

--- a/pkg/zeaburpack/packers.go
+++ b/pkg/zeaburpack/packers.go
@@ -3,6 +3,7 @@ package zeaburpack
 import (
 	"github.com/zeabur/zbpack/internal/deno"
 	"github.com/zeabur/zbpack/internal/dockerfile"
+	"github.com/zeabur/zbpack/internal/dotnet"
 	"github.com/zeabur/zbpack/internal/golang"
 	"github.com/zeabur/zbpack/internal/java"
 	"github.com/zeabur/zbpack/internal/nodejs"
@@ -26,6 +27,7 @@ func SupportedPackers() []packer.Packer {
 		java.NewPacker(),
 		deno.NewPacker(),
 		rust.NewPacker(),
+		dotnet.NewPacker(),
 		static.NewPacker(),
 	}
 }

--- a/tests/dotnet-samples/dotnetapp/Program.cs
+++ b/tests/dotnet-samples/dotnetapp/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Net;
+using System.Runtime.InteropServices;
+using static System.Console;
+
+// Ascii text: https://ascii.co.uk/text (3D Diagonol)
+
+WriteLine("""
+                         ___                              ___     
+      ,---,            ,--.'|_                          ,--.'|_   
+    ,---.'|   ,---.    |  | :,'       ,---,             |  | :,'  
+    |   | :  '   ,'\   :  : ' :   ,-+-. /  |            :  : ' :  
+    |   | | /   /   |.;__,'  /   ,--.'|'   |   ,---.  .;__,'  /   
+  ,--.__| |.   ; ,. :|  |   |   |   |  ,"' |  /     \ |  |   |    
+ /   ,'   |'   | |: ::__,'| :   |   | /  | | /    /  |:__,'| :    
+.   '  /  |'   | .; :  '  : |__ |   | |  | |.    ' / |  '  : |__  
+'   ; |:  ||   :    |  |  | '.'||   | |  |/ '   ;   /|  |  | '.'| 
+|   | '/  ' \   \  /   ;  :    ;|   | |--'  '   |  / |  ;  :    ; 
+|   :    :|  `----'    |  ,   / |   |/      |   :    |  |  ,   /  
+ \   \  /               ---`-'  '---'        \   \  /    ---`-'   
+  `----'                                      `----'              
+""");
+
+// .NET information
+WriteLine(RuntimeInformation.FrameworkDescription);
+

--- a/tests/dotnet-samples/dotnetapp/dotnetapp.csproj
+++ b/tests/dotnet-samples/dotnetapp/dotnetapp.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <PublishRelease>true</PublishRelease>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Feature description
Add support for .NET applications

## Solution description
With this PR, you will be able to generate docker images for dotnet applications. It includes test cases with a sample dotnet application. Please note that this is still a minimum implementation, and it supports simple dotnet applications. In future, we can add more revisions to support more complex dotnet applications with multiple build paths. 

## Tested frameworks
1. Dotnet console 
2. ASP.NET Web App
3. ASP.NET Web API

**Not tested for older .NET framework versions**

Please review, feedback is appreciated. 

Relates to #64 