### PR TITLE
fix(planner/python): Unstable result of Python DeterminePackageManager

### DIFF
--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -78,19 +78,22 @@ func DeterminePackageManager(ctx *pythonPlanContext) types.PackageManager {
 	cpm := &ctx.PackageManager
 
 	// Pipfile > pyproject.toml > requirements.txt
-	depFile := map[types.PackageManager]string{
-		types.PythonPackageManagerPipenv: "Pipfile",
-		types.PythonPackageManagerPoetry: "pyproject.toml",
-		types.PythonPackageManagerPip:    "requirements.txt",
+	depFiles := []struct {
+		packageManagerID types.PackageManager
+		filename         string
+	}{
+		{types.PythonPackageManagerPipenv, "Pipfile"},
+		{types.PythonPackageManagerPoetry, "pyproject.toml"},
+		{types.PythonPackageManagerPip, "requirements.txt"},
 	}
 
 	if packageManager, err := cpm.Take(); err == nil {
 		return packageManager
 	}
 
-	for pm, file := range depFile {
-		if utils.HasFile(src, file) {
-			*cpm = optional.Some(pm)
+	for _, depFile := range depFiles {
+		if utils.HasFile(src, depFile.filename) {
+			*cpm = optional.Some(depFile.packageManagerID)
 			return cpm.Unwrap()
 		}
 	}

--- a/internal/python/plan_test.go
+++ b/internal/python/plan_test.go
@@ -1,6 +1,7 @@
 package python
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -71,6 +72,22 @@ func TestPackageManager_PipenvWithOldRequirements(t *testing.T) {
 	pm := DeterminePackageManager(ctx)
 
 	assert.Equal(t, types.PythonPackageManagerPipenv, pm)
+}
+
+func TestPackageManager_PipenvWithOldRequirements_FixedOrder(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "Pipfile", nil, 0o644)
+	_ = afero.WriteFile(fs, "requirements.txt", nil, 0o644)
+
+	ctx := &pythonPlanContext{
+		Src: fs,
+	}
+
+	for i := 0; i < 1_000; i++ {
+		pm := DeterminePackageManager(ctx)
+		assert.Equal(t, types.PythonPackageManagerPipenv, pm, fmt.Sprintf("in the test round %d", i))
+		ctx.PackageManager = nil
+	}
 }
 
 func TestDetermineInstallCmd_Snapshot(t *testing.T) {


### PR DESCRIPTION
Fix the CI issue of #70 

- test(planner/python): Order must be deterministic
- fix(planner/python): Order is not deterministic
