### PR TITLE
feat(planner/dotnet): Add framework specific support

### DIFF
--- a/internal/dotnet/identify.go
+++ b/internal/dotnet/identify.go
@@ -29,9 +29,15 @@ func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
 		panic(err)
 	}
 
+	framework, err := DetermineFramework(options.SubmoduleName, options.Source)
+	if err != nil {
+		panic(err)
+	}
+
 	return types.PlanMeta{
 		"sdk":        sdkVer,
 		"entryPoint": options.SubmoduleName,
+		"framework":  framework,
 	}
 }
 

--- a/internal/dotnet/plan_test.go
+++ b/internal/dotnet/plan_test.go
@@ -25,3 +25,22 @@ func TestDetermineSDKVersion_Valid(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ver, "7.0")
 }
+
+func TestDetermineFramework_EmptyEntryPoint(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	framework, err := DetermineFramework("", fs)
+	assert.ErrorContains(t, err, "Unable to determine framework")
+	assert.Empty(t, framework)
+}
+
+func TestDetermineFramework_Valid(t *testing.T) {
+	path := "../../tests/dotnet-samples/dotnetapp/"
+	assert.DirExists(t, path)
+
+	fs := afero.NewBasePathFs(afero.NewOsFs(), path)
+
+	framework, err := DetermineFramework("dotnetapp", fs)
+	assert.NoError(t, err)
+	assert.Equal(t, framework, "console")
+}

--- a/internal/dotnet/templates/nginx-conf.Dockerfile
+++ b/internal/dotnet/templates/nginx-conf.Dockerfile
@@ -1,0 +1,10 @@
+{{define "nginx-conf"}} \
+server { \
+    listen \$PORT; \
+    \
+    location / { \
+        root /usr/share/nginx/html/static; \
+        try_files \$uri \$uri/ /index.html =404; \
+    } \
+} \
+{{end}}

--- a/internal/dotnet/templates/nginx-runtime.Dockerfile
+++ b/internal/dotnet/templates/nginx-runtime.Dockerfile
@@ -1,0 +1,8 @@
+{{define "nginx-runtime"}}
+FROM nginx:alpine as runtime
+ENV PORT 8080
+WORKDIR /usr/share/nginx/html
+COPY --from=build /app/wwwroot ./static/
+RUN echo "{{ template "nginx-conf" . }}" > ./nginx.conf
+CMD ["/bin/sh" , "-c" , "envsubst '$PORT' < /usr/share/nginx/html/nginx.conf | tee /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]
+{{end}}

--- a/internal/dotnet/templates/template.Dockerfile
+++ b/internal/dotnet/templates/template.Dockerfile
@@ -1,0 +1,21 @@
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:{{.DotnetVer}} AS build
+WORKDIR /source
+		
+# copy csproj and restore as distinct layers
+COPY *.csproj ./
+RUN dotnet restore
+		
+# copy everything else and build app
+COPY . ./
+WORKDIR /source
+RUN dotnet publish -c release -o /app
+		
+# final stage/image
+{{ if .Static }}{{ template "nginx-runtime" . }}{{ else }}
+FROM mcr.microsoft.com/dotnet/aspnet:{{.DotnetVer}}
+ENV PORT 8080
+WORKDIR /app
+COPY --from=build /app ./
+CMD ASPNETCORE_URLS=http://+:$PORT dotnet {{.Out}}.dll
+{{ end }}

--- a/pkg/types/plan.go
+++ b/pkg/types/plan.go
@@ -147,3 +147,15 @@ const (
 )
 
 //revive:enable:exported
+
+// DotnetFramework represents the framework of a Dotnet project.
+type DotnetFramework string
+
+//revive:disable:exported
+const (
+	DotnetFrameworkAspnet     DotnetFramework = "aspnet"
+	DotnetFrameworkBlazorWasm DotnetFramework = "blazorwasm"
+	DotnetFrameworkConsole    DotnetFramework = "console"
+)
+
+//revive:enable:exported


### PR DESCRIPTION
### Feature description
Add support for Blazor WebAssembly and configure a default port.

### Solution description
- Added support for Blazor wasm. Blazor wasm serves static files, unlike other .NET technologies, and in order to serve the static files we need a server like nginx. 
- Configured the Dockerfile with a default port 8080, this can be overwritten by suppling a new value during runtime. 

Closes #66 