### PR TITLE
fix(lib): Don't construct if ref is scratch

### DIFF
--- a/pkg/zeaburpack/ref.go
+++ b/pkg/zeaburpack/ref.go
@@ -44,6 +44,11 @@ func (rc referenceConstructor) Construct(rawRefString string) string {
 		return rawRefString
 	}
 
+	// If ref is `scratch`, we skip.
+	if rawRefString == "scratch" {
+		return rawRefString
+	}
+
 	// Safety: ptr != nil.
 	proxyRegistry := *proxyRegistryPtr
 

--- a/pkg/zeaburpack/ref_test.go
+++ b/pkg/zeaburpack/ref_test.go
@@ -23,6 +23,7 @@ func TestReferenceConstructor_Construct(t *testing.T) {
 		"other.io/library/alpine:latest":    "other.io/library/alpine:latest",
 		"other.io/library/alpine:3.12":      "other.io/library/alpine:3.12",
 		"other.io:1234/library/alpine:3.12": "other.io:1234/library/alpine:3.12",
+		"scratch":                           "scratch",
 	}
 
 	ref := newReferenceConstructor(&proxy)


### PR DESCRIPTION
Fixes:

```
Expected :scratch
Actual   :zeabur.tld/proxyowo/library/scratch
```