### PR TITLE
perf(planner/python): Optimize Python install command order for layer caching

### DIFF
--- a/internal/python/__snapshots__/plan_test.snap
+++ b/internal/python/__snapshots__/plan_test.snap
@@ -1,46 +1,67 @@
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-wsgi - 1]
-pip install pipenv && pipenv install && pipenv install gunicorn
+RUN pip install pipenv
+RUN pipenv install gunicorn
+COPY Pipfile* .
+RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-wsgi - 1]
-pip install poetry && poetry install && poetry add gunicorn
+RUN pip install poetry
+RUN poetry add gunicorn
+COPY poetry.lock* pyproject.toml* .
+RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-none - 1]
-pip install poetry && poetry install
+RUN pip install poetry
+COPY poetry.lock* pyproject.toml* .
+RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-none - 1]
-pip install pipenv && pipenv install
+RUN pip install pipenv
+COPY Pipfile* .
+RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-wsgi - 1]
-pip install -r requirements.txt && pip install gunicorn
+RUN pip install gunicorn
+COPY requirements.txt* .
+RUN pip install -r requirements.txt
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-none - 1]
-pip install -r requirements.txt
+COPY requirements.txt* .
+RUN pip install -r requirements.txt
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-fastapi - 1]
-pip install -r requirements.txt && pip install uvicorn
+RUN pip install uvicorn
+COPY requirements.txt* .
+RUN pip install -r requirements.txt
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-fastapi - 1]
-pip install poetry && poetry install && poetry add uvicorn
+RUN pip install poetry
+RUN poetry add uvicorn
+COPY poetry.lock* pyproject.toml* .
+RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-fastapi - 1]
-pip install pipenv && pipenv install && pipenv install uvicorn
+RUN pip install pipenv
+RUN pipenv install uvicorn
+COPY Pipfile* .
+RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/unknown-with-wsgi - 1]
-pip install gunicorn
+RUN pip install gunicorn
 ---
 
 [TestDetermineInstallCmd_Snapshot/unknown-with-fastapi - 1]
-pip install uvicorn
+RUN pip install uvicorn
 ---
 
 [TestDetermineInstallCmd_Snapshot/unknown-none - 1]
@@ -112,49 +133,73 @@ poetry run gunicorn --bind :8080 wsgi.py
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-static-nginx-django - 1]
-pip install poetry && poetry install && poetry add gunicorn && python manage.py collectstatic --noinput
+RUN pip install poetry
+RUN poetry add gunicorn
+COPY poetry.lock* pyproject.toml* .
+RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-static-nginx - 1]
-pip install poetry && poetry install && poetry add gunicorn
+RUN pip install poetry
+RUN poetry add gunicorn
+COPY poetry.lock* pyproject.toml* .
+RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-static-nginx - 1]
-pip install -r requirements.txt && pip install gunicorn
+RUN pip install gunicorn
+COPY requirements.txt* .
+RUN pip install -r requirements.txt
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-static-django - 1]
-pip install -r requirements.txt && pip install gunicorn && python manage.py collectstatic --noinput
+RUN pip install gunicorn
+COPY requirements.txt* .
+RUN pip install -r requirements.txt
 ---
 
 [TestDetermineInstallCmd_Snapshot/unknown-with-static-django - 1]
-pip install gunicorn && python manage.py collectstatic --noinput
+RUN pip install gunicorn
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-static-django - 1]
-pip install poetry && poetry install && poetry add gunicorn && python manage.py collectstatic --noinput
+RUN pip install poetry
+RUN poetry add gunicorn
+COPY poetry.lock* pyproject.toml* .
+RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/unknown-with-static-nginx-django - 1]
-pip install gunicorn && python manage.py collectstatic --noinput
+RUN pip install gunicorn
 ---
 
 [TestDetermineInstallCmd_Snapshot/unknown-with-static-nginx - 1]
-pip install gunicorn
+RUN pip install gunicorn
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-static-nginx-django - 1]
-pip install pipenv && pipenv install && pipenv install gunicorn && python manage.py collectstatic --noinput
+RUN pip install pipenv
+RUN pipenv install gunicorn
+COPY Pipfile* .
+RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-static-nginx - 1]
-pip install pipenv && pipenv install && pipenv install gunicorn
+RUN pip install pipenv
+RUN pipenv install gunicorn
+COPY Pipfile* .
+RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-static-nginx-django - 1]
-pip install -r requirements.txt && pip install gunicorn && python manage.py collectstatic --noinput
+RUN pip install gunicorn
+COPY requirements.txt* .
+RUN pip install -r requirements.txt
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-static-django - 1]
-pip install pipenv && pipenv install && pipenv install gunicorn && python manage.py collectstatic --noinput
+RUN pip install pipenv
+RUN pipenv install gunicorn
+COPY Pipfile* .
+RUN pipenv install
 ---

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -409,60 +409,63 @@ func determineInstallCmd(ctx *pythonPlanContext) string {
 	pm := DeterminePackageManager(ctx)
 	wsgi := DetermineWsgi(ctx)
 	framework := DetermineFramework(ctx)
-	staticInfo := DetermineStaticInfo(ctx)
 
-	// Will be joined with `&&`
-	andCommands := []string{}
+	// will be joined by newline
+	var commands []string
 
 	switch pm {
 	case types.PythonPackageManagerPipenv:
-		andCommands = append(andCommands, "pip install pipenv", "pipenv install")
+		commands = append(commands, "RUN pip install pipenv")
 
 		if wsgi != "" {
 			if framework == types.PythonFrameworkFastapi {
-				andCommands = append(andCommands, "pipenv install uvicorn")
+				commands = append(commands, "RUN pipenv install uvicorn")
 			} else {
-				andCommands = append(andCommands, "pipenv install gunicorn")
+				commands = append(commands, "RUN pipenv install gunicorn")
 			}
 		}
+		commands = append(commands, "COPY Pipfile* .", "RUN pipenv install")
 	case types.PythonPackageManagerPoetry:
-		andCommands = append(andCommands, "pip install poetry", "poetry install")
+		commands = append(commands, "RUN pip install poetry")
 
 		if wsgi != "" {
 			if framework == types.PythonFrameworkFastapi {
-				andCommands = append(andCommands, "poetry add uvicorn")
+				commands = append(commands, "RUN poetry add uvicorn")
 			} else {
-				andCommands = append(andCommands, "poetry add gunicorn")
+				commands = append(commands, "RUN poetry add gunicorn")
 			}
 		}
+		commands = append(commands, "COPY poetry.lock* pyproject.toml* .", "RUN poetry install")
 	case types.PythonPackageManagerPdm:
-		andCommands = append(andCommands, "pip install pdm", "pdm install")
+		commands = append(commands, "COPY pdm.lock* pyproject.toml* .", "RUN pip install pdm")
 		if wsgi != "" {
 			if framework == types.PythonFrameworkFastapi {
-				andCommands = append(andCommands, "pdm add uvicorn")
+				commands = append(commands, "RUN pdm add uvicorn")
 			} else {
-				andCommands = append(andCommands, "pdm add gunicorn")
+				commands = append(commands, "RUN pdm add gunicorn")
 			}
 		}
+		commands = append(commands, "RUN pdm install")
 	case types.PythonPackageManagerPip:
-		andCommands = append(andCommands, "pip install -r requirements.txt")
-		fallthrough
+		if wsgi != "" {
+			if framework == types.PythonFrameworkFastapi {
+				commands = append(commands, "RUN pip install uvicorn")
+			} else {
+				commands = append(commands, "RUN pip install gunicorn")
+			}
+		}
+		commands = append(commands, "COPY requirements.txt* .", "RUN pip install -r requirements.txt")
 	default:
 		if wsgi != "" {
 			if framework == types.PythonFrameworkFastapi {
-				andCommands = append(andCommands, "pip install uvicorn")
+				commands = append(commands, "RUN pip install uvicorn")
 			} else {
-				andCommands = append(andCommands, "pip install gunicorn")
+				commands = append(commands, "RUN pip install gunicorn")
 			}
 		}
 	}
 
-	if staticInfo.DjangoEnabled() {
-		// We need to collect static files if we are using Django.
-		andCommands = append(andCommands, "python manage.py collectstatic --noinput")
-	}
-
-	command := strings.Join(andCommands, " && ")
+	command := strings.Join(commands, "\n")
 	if command != "" {
 		return command
 	}
@@ -594,6 +597,17 @@ func determinePythonVersionWithPoetry(ctx *pythonPlanContext) string {
 	return defaultPython3Version
 }
 
+func determineBuildCmd(ctx *pythonPlanContext) string {
+	staticInfo := DetermineStaticInfo(ctx)
+
+	if staticInfo.DjangoEnabled() {
+		// We need to collect static files if we are using Django.
+		return "RUN python manage.py collectstatic --noinput"
+	}
+
+	return ""
+}
+
 // GetMetaOptions is the options for GetMeta.
 type GetMetaOptions struct {
 	Src afero.Fs
@@ -625,6 +639,11 @@ func GetMeta(opt GetMetaOptions) types.PlanMeta {
 
 	installCmd := determineInstallCmd(ctx)
 	meta["install"] = installCmd
+
+	buildCmd := determineBuildCmd(ctx)
+	if buildCmd != "" {
+		meta["build"] = buildCmd
+	}
 
 	startCmd := determineStartCmd(ctx)
 	meta["start"] = startCmd

--- a/internal/python/python.go
+++ b/internal/python/python.go
@@ -8,6 +8,7 @@ import (
 // GenerateDockerfile generates the Dockerfile for Python projects.
 func GenerateDockerfile(meta types.PlanMeta) (string, error) {
 	installCmd := meta["install"]
+	buildCmd := meta["build"]
 	startCmd := meta["start"]
 	aptDeps := meta["apt-deps"]
 	staticMeta := staticInfoFromMeta(meta)
@@ -30,8 +31,8 @@ server { \
 			alias ` + staticMeta.StaticHostDir + ` ; \` + `
 		} \
     }"> /etc/nginx/conf.d/default.conf ` + ` && rm -rf /var/lib/apt/lists/*
+` + installCmd + `
 COPY . .
-RUN ` + installCmd + `
 EXPOSE 8080
 CMD ` + startCmd
 	} else {
@@ -40,8 +41,9 @@ WORKDIR /app
 RUN apt-get update
 RUN apt-get install -y ` + aptDeps + `
 RUN rm -rf /var/lib/apt/lists/*
+` + installCmd + `
 COPY . .
-RUN ` + installCmd + `
+` + buildCmd + `
 EXPOSE 8080
 CMD ` + startCmd
 	}


### PR DESCRIPTION
Run install commands in the following order to fully use Docker's layer caching:

1. install the package manager if not pip
2. install the wsgi if needed
3. copy the dependency files
4. install dependency
5. copy all files
6. run build command (for example, Django's collect static command)