### PR TITLE
feat(planner/static): Support hugo configuration directory mode & test case

### DIFF
--- a/internal/static/identify.go
+++ b/internal/static/identify.go
@@ -1,9 +1,8 @@
 package static
 
 import (
-	"strings"
-
 	"github.com/spf13/afero"
+	"strings"
 
 	"github.com/zeabur/zbpack/internal/utils"
 	"github.com/zeabur/zbpack/pkg/plan"
@@ -23,12 +22,12 @@ func (i *identify) PlanType() types.PlanType {
 }
 
 func (i *identify) Match(fs afero.Fs) bool {
-	return utils.HasFile(fs, "index.html", "hugo.toml")
+	return utils.HasFile(fs, "index.html", "hugo.toml", "config/_default/hugo.toml")
 }
 
 func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
 
-	if utils.HasFile(options.Source, "hugo.toml") {
+	if utils.HasFile(options.Source, "hugo.toml", "config/_default/hugo.toml") {
 		return types.PlanMeta{"framework": "hugo"}
 	}
 

--- a/tests/static-hugo-config-dir/archetypes/default.md
+++ b/tests/static-hugo-config-dir/archetypes/default.md
@@ -1,0 +1,5 @@
++++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = {{ .Date }}
+draft = true
++++

--- a/tests/static-hugo-config-dir/config/_default/hugo.toml
+++ b/tests/static-hugo-config-dir/config/_default/hugo.toml
@@ -1,0 +1,3 @@
+baseURL = 'https://example.org/'
+languageCode = 'en-us'
+title = 'My New Hugo Site'

--- a/tests/static-hugo-config-dir/public/categories/index.xml
+++ b/tests/static-hugo-config-dir/public/categories/index.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Categories on My New Hugo Site</title>
+    <link>https://example.org/categories/</link>
+    <description>Recent content in Categories on My New Hugo Site</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-us</language><atom:link href="https://example.org/categories/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/tests/static-hugo-config-dir/public/index.xml
+++ b/tests/static-hugo-config-dir/public/index.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>My New Hugo Site</title>
+    <link>https://example.org/</link>
+    <description>Recent content on My New Hugo Site</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-us</language><atom:link href="https://example.org/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/tests/static-hugo-config-dir/public/sitemap.xml
+++ b/tests/static-hugo-config-dir/public/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://example.org/categories/</loc>
+  </url><url>
+    <loc>https://example.org/</loc>
+  </url><url>
+    <loc>https://example.org/tags/</loc>
+  </url>
+</urlset>

--- a/tests/static-hugo-config-dir/public/tags/index.xml
+++ b/tests/static-hugo-config-dir/public/tags/index.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Tags on My New Hugo Site</title>
+    <link>https://example.org/tags/</link>
+    <description>Recent content in Tags on My New Hugo Site</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-us</language><atom:link href="https://example.org/tags/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>


### PR DESCRIPTION
<img width="779" alt="image" src="https://github.com/zeabur/zbpack/assets/10394160/8e635025-3513-4247-ad61-3a474fdf8620">

Enhance the detection of the Hugo framework by searching in `config/_default`

