### PR TITLE
feat(planner/python): Implement streamlit support

### DIFF
--- a/internal/python/__snapshots__/plan_test.snap
+++ b/internal/python/__snapshots__/plan_test.snap
@@ -65,7 +65,7 @@ RUN pip install uvicorn
 ---
 
 [TestDetermineInstallCmd_Snapshot/unknown-none - 1]
-echo "skip install"
+RUN echo "skip install"
 ---
 
 [TestDetermineStartCmd_Snapshot/pipenv-with-wsgi - 1]

--- a/internal/python/__snapshots__/plan_test.snap
+++ b/internal/python/__snapshots__/plan_test.snap
@@ -203,3 +203,27 @@ RUN pipenv install gunicorn
 COPY Pipfile* .
 RUN pipenv install
 ---
+
+[TestDetermineInstallCmd_Snapshot/pipenv-with-streamlit-entry - 1]
+RUN pip install pipenv
+RUN pipenv install streamlit
+COPY Pipfile* .
+RUN pipenv install
+---
+
+[TestDetermineInstallCmd_Snapshot/pip-with-streamlit-entry - 1]
+RUN pip install streamlit
+COPY requirements.txt* .
+RUN pip install -r requirements.txt
+---
+
+[TestDetermineInstallCmd_Snapshot/poetry-with-streamlit-entry - 1]
+RUN pip install poetry
+RUN poetry add streamlit
+COPY poetry.lock* pyproject.toml* .
+RUN poetry install
+---
+
+[TestDetermineInstallCmd_Snapshot/unknown-with-streamlit-entry - 1]
+RUN pip install streamlit
+---

--- a/internal/python/identify.go
+++ b/internal/python/identify.go
@@ -22,7 +22,7 @@ func (i *identify) PlanType() types.PlanType {
 func (i *identify) Match(fs afero.Fs) bool {
 	return utils.HasFile(
 		fs,
-		"app.py", "main.py", "app.py", "manage.py", "requirements.txt",
+		"app.py", "main.py", "app.py", "manage.py", "requirements.txt", "streamlit_app.py",
 	)
 }
 

--- a/internal/python/identify.go
+++ b/internal/python/identify.go
@@ -27,7 +27,7 @@ func (i *identify) Match(fs afero.Fs) bool {
 }
 
 func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
-	return GetMeta(GetMetaOptions{Src: options.Source})
+	return GetMeta(GetMetaOptions{Src: options.Source, Config: options.Config})
 }
 
 var _ plan.Identifier = (*identify)(nil)

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -492,7 +492,7 @@ func determineInstallCmd(ctx *pythonPlanContext) string {
 	if command != "" {
 		return command
 	}
-	return "echo \"skip install\""
+	return "RUN echo \"skip install\""
 }
 
 func determineAptDependencies(ctx *pythonPlanContext) []string {

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -12,11 +12,13 @@ import (
 	"github.com/moznion/go-optional"
 	"github.com/spf13/afero"
 	"github.com/zeabur/zbpack/internal/utils"
+	"github.com/zeabur/zbpack/pkg/plan"
 	"github.com/zeabur/zbpack/pkg/types"
 )
 
 type pythonPlanContext struct {
 	Src            afero.Fs
+	Config         plan.ImmutableProjectConfiguration
 	PackageManager optional.Option[types.PackageManager]
 	Framework      optional.Option[types.PythonFramework]
 	Entry          optional.Option[string]
@@ -635,7 +637,8 @@ func determineBuildCmd(ctx *pythonPlanContext) string {
 
 // GetMetaOptions is the options for GetMeta.
 type GetMetaOptions struct {
-	Src afero.Fs
+	Src    afero.Fs
+	Config plan.ImmutableProjectConfiguration
 }
 
 // GetMeta returns the metadata of a Python project.
@@ -643,7 +646,8 @@ func GetMeta(opt GetMetaOptions) types.PlanMeta {
 	meta := types.PlanMeta{}
 
 	ctx := &pythonPlanContext{
-		Src: opt.Src,
+		Src:    opt.Src,
+		Config: opt.Config,
 	}
 
 	pm := DeterminePackageManager(ctx)

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -582,7 +582,7 @@ func determineStartCmd(ctx *pythonPlanContext) string {
 	}
 
 	if streamlitEntry := determineStreamlitEntry(ctx); streamlitEntry != "" {
-		commandSegment = append(commandSegment, "streamlit run", streamlitEntry)
+		commandSegment = append(commandSegment, "streamlit run", streamlitEntry, "--server.port=8080", "--server.address=0.0.0.0")
 	} else if wsgi != "" {
 		wsgilistenedPort := "8080"
 

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -458,6 +458,11 @@ func determineInstallCmd(ctx *pythonPlanContext) string {
 				commands = append(commands, "RUN pipenv install gunicorn")
 			}
 		}
+
+		if determineStreamlitEntry(ctx) != "" {
+			commands = append(commands, "RUN pipenv install streamlit")
+		}
+
 		commands = append(commands, "COPY Pipfile* .", "RUN pipenv install")
 	case types.PythonPackageManagerPoetry:
 		commands = append(commands, "RUN pip install poetry")
@@ -469,9 +474,15 @@ func determineInstallCmd(ctx *pythonPlanContext) string {
 				commands = append(commands, "RUN poetry add gunicorn")
 			}
 		}
+
+		if determineStreamlitEntry(ctx) != "" {
+			commands = append(commands, "RUN poetry add streamlit")
+		}
+
 		commands = append(commands, "COPY poetry.lock* pyproject.toml* .", "RUN poetry install")
 	case types.PythonPackageManagerPdm:
 		commands = append(commands, "COPY pdm.lock* pyproject.toml* .", "RUN pip install pdm")
+
 		if wsgi != "" {
 			if framework == types.PythonFrameworkFastapi {
 				commands = append(commands, "RUN pdm add uvicorn")
@@ -479,6 +490,11 @@ func determineInstallCmd(ctx *pythonPlanContext) string {
 				commands = append(commands, "RUN pdm add gunicorn")
 			}
 		}
+
+		if determineStreamlitEntry(ctx) != "" {
+			commands = append(commands, "RUN pdm add streamlit")
+		}
+
 		commands = append(commands, "RUN pdm install")
 	case types.PythonPackageManagerPip:
 		if wsgi != "" {
@@ -488,6 +504,11 @@ func determineInstallCmd(ctx *pythonPlanContext) string {
 				commands = append(commands, "RUN pip install gunicorn")
 			}
 		}
+
+		if determineStreamlitEntry(ctx) != "" {
+			commands = append(commands, "RUN pip install streamlit")
+		}
+
 		commands = append(commands, "COPY requirements.txt* .", "RUN pip install -r requirements.txt")
 	default:
 		if wsgi != "" {
@@ -496,6 +517,10 @@ func determineInstallCmd(ctx *pythonPlanContext) string {
 			} else {
 				commands = append(commands, "RUN pip install gunicorn")
 			}
+		}
+
+		if determineStreamlitEntry(ctx) != "" {
+			commands = append(commands, "RUN pip install streamlit")
 		}
 	}
 

--- a/internal/python/plan_test.go
+++ b/internal/python/plan_test.go
@@ -190,6 +190,7 @@ func TestDetermineInstallCmd_Snapshot(t *testing.T) {
 		WithStaticDjango      = "with-static-django"
 		WithStaticNginx       = "with-static-nginx"
 		WithStaticNginxDjango = "with-static-nginx-django"
+		WithStreamlitEntry    = "with-streamlit-entry"
 		None                  = "none"
 	)
 
@@ -206,13 +207,19 @@ func TestDetermineInstallCmd_Snapshot(t *testing.T) {
 			WithStaticNginx,
 			WithStaticDjango,
 			WithStaticNginxDjango,
+			WithStreamlitEntry,
 			None,
 		} {
 			mode := mode
 			t.Run(string(pm)+"-"+mode, func(t *testing.T) {
 				t.Parallel()
 
+				fs := afero.NewMemMapFs()
+				config := plan.NewProjectConfigurationFromFs(fs, "")
+
 				ctx := pythonPlanContext{
+					Src:            fs,
+					Config:         config,
 					PackageManager: optional.Some(pm),
 				}
 
@@ -255,6 +262,10 @@ func TestDetermineInstallCmd_Snapshot(t *testing.T) {
 						StaticURLPath: "/static",
 						StaticHostDir: "/app/static",
 					})
+				}
+
+				if mode == WithStreamlitEntry {
+					ctx.StreamlitEntry = optional.Some("streamlit_app.py")
 				}
 
 				ic := determineInstallCmd(&ctx)

--- a/internal/python/plan_test.go
+++ b/internal/python/plan_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/moznion/go-optional"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/zbpack/pkg/plan"
 	"github.com/zeabur/zbpack/pkg/types"
 )
 
@@ -283,7 +284,11 @@ func TestDetermineStartCmd_Snapshot(t *testing.T) {
 			t.Run(string(pm)+"-"+mode, func(t *testing.T) {
 				t.Parallel()
 
+				fs := afero.NewMemMapFs()
+
 				ctx := pythonPlanContext{
+					Src:            fs,
+					Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 					PackageManager: optional.Some(pm),
 					Entry:          optional.Some("app.py"),
 				}
@@ -725,4 +730,61 @@ func TestHasDependencyWithFile_Unknown(t *testing.T) {
 
 	assert.False(t, HasDependencyWithFile(ctx, "flask"))
 	assert.False(t, HasDependencyWithFile(ctx, "bar"))
+}
+
+func TestDetermineStreamlitEntry_ByFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "streamlit_app.py", []byte(`import streamlit as st
+x = st.slider("Select a value")
+st.write(x, "squared is", x * x)`), 0o644)
+	_ = afero.WriteFile(fs, "requirements.txt", []byte("streamlit"), 0o644)
+
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+
+	ctx := &pythonPlanContext{
+		Src:            fs,
+		Config:         config,
+		PackageManager: optional.Some(types.PythonPackageManagerUnknown),
+	}
+
+	assert.Equal(t, "streamlit_app.py", determineStreamlitEntry(ctx))
+}
+
+func TestDetermineStreamlitEntry_ByConfig(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "zeabur_streamlit_demo.py", []byte(`import streamlit as st
+x = st.slider("Select a value")
+st.write(x, "squared is", x * x)`), 0o644)
+	_ = afero.WriteFile(fs, "requirements.txt", []byte("streamlit"), 0o644)
+	_ = afero.WriteFile(fs, "zbpack.json", []byte(`{"streamlit": {"entry": "zeabur_streamlit_demo.py"}}`), 0o644)
+
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+
+	ctx := &pythonPlanContext{
+		Src:            fs,
+		Config:         config,
+		PackageManager: optional.Some(types.PythonPackageManagerUnknown),
+	}
+
+	assert.Equal(t, "zeabur_streamlit_demo.py", determineStreamlitEntry(ctx))
+}
+
+func TestDetermineStreamlitEntry_ConfigPrecedeConvention(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "zeabur_streamlit_demo.py", []byte(`import streamlit as st
+x = st.slider("Select a value")
+st.write(x, "squared is", x * x)`), 0o644)
+	_ = afero.WriteFile(fs, "app.py", []byte(`print('not me')`), 0o644)
+	_ = afero.WriteFile(fs, "requirements.txt", []byte("streamlit"), 0o644)
+	_ = afero.WriteFile(fs, "zbpack.json", []byte(`{"streamlit": {"entry": "zeabur_streamlit_demo.py"}}`), 0o644)
+
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+
+	ctx := &pythonPlanContext{
+		Src:            fs,
+		Config:         config,
+		PackageManager: optional.Some(types.PythonPackageManagerUnknown),
+	}
+
+	assert.Equal(t, "zeabur_streamlit_demo.py", determineStreamlitEntry(ctx))
 }

--- a/tests/python-streamlit/streamlit_app.py
+++ b/tests/python-streamlit/streamlit_app.py
@@ -1,0 +1,3 @@
+import streamlit as st
+x = st.slider("Select a value")
+st.write(x, "squared is", x * x)


### PR DESCRIPTION
# Spec

## Discovery behavior

1. Projects with `zbpack.json` including `{"streamlit": {"entry": "<entry>"}}`. <entry> will be used.
    - `requirements.txt` is required if there is no any file named `app.py`, `main.py` or `streamlit_app.py`.
2. For `app.py`, `main.py`, `streamlit_app.py` files including `import streamlit`: such file will be used.

## Installation behavior

For all Streamlit projects, we install `streamlit` automatically even there is no `requirements.txt`.

## Launch behavior

We run it with `<pkg-manager-pre-args> streamlit run <entry> --server.port=8080 --server.address=0.0.0.0`, while `8080` is Zeabur's default listening port.