### PR TITLE
ZEA-2417: ZBPACK_SERVERLESS=1 with zbpack.json

### DIFF
--- a/internal/golang/identify.go
+++ b/internal/golang/identify.go
@@ -27,6 +27,7 @@ func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
 	return GetMeta(
 		GetMetaOptions{
 			Src:           options.Source,
+			Config:        options.Config,
 			SubmoduleName: options.SubmoduleName,
 		},
 	)

--- a/internal/golang/plan.go
+++ b/internal/golang/plan.go
@@ -2,17 +2,19 @@ package golang
 
 import (
 	"bufio"
-	"os"
 	"path"
 
 	"github.com/moznion/go-optional"
 	"github.com/spf13/afero"
 	"github.com/zeabur/zbpack/internal/utils"
+	"github.com/zeabur/zbpack/pkg/plan"
 	"github.com/zeabur/zbpack/pkg/types"
 )
 
 type goPlanContext struct {
-	Src           afero.Fs
+	Src    afero.Fs
+	Config plan.ImmutableProjectConfiguration
+
 	SubmoduleName string
 
 	GoVersion optional.Option[string]
@@ -80,6 +82,7 @@ func getEntry(ctx *goPlanContext) string {
 // GetMetaOptions is the options for GetMeta.
 type GetMetaOptions struct {
 	Src           afero.Fs
+	Config        plan.ImmutableProjectConfiguration
 	SubmoduleName string
 }
 
@@ -99,7 +102,11 @@ func getServerless(ctx *goPlanContext) bool {
 
 // GetMeta gets the metadata of the Go project.
 func GetMeta(opt GetMetaOptions) types.PlanMeta {
-	ctx := &goPlanContext{Src: opt.Src, SubmoduleName: opt.SubmoduleName}
+	ctx := &goPlanContext{
+		Src:           opt.Src,
+		Config:        opt.Config,
+		SubmoduleName: opt.SubmoduleName,
+	}
 	meta := types.PlanMeta{}
 
 	goVersion := getGoVersion(ctx)

--- a/internal/golang/plan.go
+++ b/internal/golang/plan.go
@@ -87,17 +87,7 @@ type GetMetaOptions struct {
 }
 
 func getServerless(ctx *goPlanContext) bool {
-	fcEnv := os.Getenv("FORCE_CONTAINERIZED")
-	if fcEnv == "true" || fcEnv == "1" {
-		return false
-	}
-
-	zsEnv := os.Getenv("ZBPACK_SERVERLESS")
-	if zsEnv == "true" || zsEnv == "1" {
-		return true
-	}
-
-	return false
+	return utils.GetExplicitServerlessConfig(ctx.Config).TakeOr(false)
 }
 
 // GetMeta gets the metadata of the Go project.

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -3,7 +3,6 @@ package nodejs
 import (
 	"encoding/json"
 	"log"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -667,14 +666,8 @@ func GetStaticOutputDir(ctx *nodePlanContext) string {
 }
 
 func getServerless(ctx *nodePlanContext) bool {
-	fcEnv := os.Getenv("FORCE_CONTAINERIZED")
-	if fcEnv == "true" || fcEnv == "1" {
-		return false
-	}
-
-	zsEnv := os.Getenv("ZBPACK_SERVERLESS")
-	if zsEnv == "true" || zsEnv == "1" {
-		return true
+	if value, err := utils.GetExplicitServerlessConfig(ctx.Config).Take(); err == nil {
+		return value
 	}
 
 	sl := &ctx.Serverless

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -640,17 +639,7 @@ type GetMetaOptions struct {
 }
 
 func getServerless(ctx *pythonPlanContext) bool {
-	fcEnv := os.Getenv("FORCE_CONTAINERIZED")
-	if fcEnv == "true" || fcEnv == "1" {
-		return false
-	}
-
-	zsEnv := os.Getenv("ZBPACK_SERVERLESS")
-	if zsEnv == "true" || zsEnv == "1" {
-		return true
-	}
-
-	return false
+	return utils.GetExplicitServerlessConfig(ctx.Config).TakeOr(false)
 }
 
 // GetMeta returns the metadata of a Python project.

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/moznion/go-optional"
+	"github.com/spf13/cast"
+	"github.com/zeabur/zbpack/pkg/plan"
+)
+
+// GetExplicitServerlessConfig gets the serverless flag from the project configuration.
+//
+// When the serverless flag is not set, it will be determined by the FORCE_CONTAINERIZED
+// and ZBPACK_SERVERLESS environment variables.
+// If all of them are not set, it returns None for consumers to determine the default value.
+func GetExplicitServerlessConfig(config plan.ImmutableProjectConfiguration) optional.Option[bool] {
+	serverlessConfig := plan.Cast(config.Get("serverless"), cast.ToBoolE)
+	if value, err := serverlessConfig.Take(); err == nil {
+		return optional.Some(value)
+	}
+
+	fcEnv := os.Getenv("FORCE_CONTAINERIZED")
+	if fcEnv == "true" || fcEnv == "1" {
+		return optional.Some(true)
+	}
+
+	zsEnv := os.Getenv("ZBPACK_SERVERLESS")
+	if zsEnv == "true" || zsEnv == "1" {
+		return optional.Some(true)
+	}
+
+	return optional.None[bool]()
+}

--- a/internal/utils/config.go
+++ b/internal/utils/config.go
@@ -14,11 +14,6 @@ import (
 // and ZBPACK_SERVERLESS environment variables.
 // If all of them are not set, it returns None for consumers to determine the default value.
 func GetExplicitServerlessConfig(config plan.ImmutableProjectConfiguration) optional.Option[bool] {
-	serverlessConfig := plan.Cast(config.Get("serverless"), cast.ToBoolE)
-	if value, err := serverlessConfig.Take(); err == nil {
-		return optional.Some(value)
-	}
-
 	fcEnv := os.Getenv("FORCE_CONTAINERIZED")
 	if fcEnv == "true" || fcEnv == "1" {
 		return optional.Some(true)
@@ -27,6 +22,11 @@ func GetExplicitServerlessConfig(config plan.ImmutableProjectConfiguration) opti
 	zsEnv := os.Getenv("ZBPACK_SERVERLESS")
 	if zsEnv == "true" || zsEnv == "1" {
 		return optional.Some(true)
+	}
+
+	serverlessConfig := plan.Cast(config.Get("serverless"), cast.ToBoolE)
+	if value, err := serverlessConfig.Take(); err == nil {
+		return optional.Some(value)
 	}
 
 	return optional.None[bool]()


### PR DESCRIPTION
- feat(planner/golang): Inject project configuration
- feat(utils): Add "GetExplicitServerlessConfig" function
- refactor(planner): getServerless() calls GetExplicitServerlessConfig
