### PR TITLE
ZEA-2448: Customizable submodule name in CLI

### DIFF
--- a/internal/zbpack/helper.go
+++ b/internal/zbpack/helper.go
@@ -38,6 +38,10 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 // GetSubmoduleName is used to get submodule name from path.
 func GetSubmoduleName(path string) (submoduleName string, err error) {
+	if userSubmoduleName != "" {
+		return userSubmoduleName, nil
+	}
+
 	var absPath string
 	if strings.HasPrefix(path, "https://") {
 		absPath = path

--- a/internal/zbpack/zbpack.go
+++ b/internal/zbpack/zbpack.go
@@ -90,7 +90,7 @@ func build(path string) error {
 		log.Fatalln(err)
 	}
 
-	trueValue := true
+	log.Printf("using submoduleName: %s", submoduleName)
 
 	return zeaburpack.Build(
 		&zeaburpack.BuildOptions{
@@ -107,6 +107,8 @@ func plan(path string) error {
 	if err != nil {
 		log.Fatalln(err)
 	}
+
+	log.Printf("using submoduleName: %s", submoduleName)
 
 	githubToken := os.Getenv("GITHUB_ACCESS_TOKEN")
 	if strings.HasPrefix(path, "https://github.com") && githubToken == "" {

--- a/internal/zbpack/zbpack.go
+++ b/internal/zbpack/zbpack.go
@@ -15,7 +15,9 @@ import (
 var (
 	// info option is used to analyze and print project information.
 	info bool
-	cmd  = &cobra.Command{
+	// userSubmoduleName option is used to specify the submodule name of this project manually
+	userSubmoduleName string
+	cmd               = &cobra.Command{
 		Use:   "zbpack",
 		Short: "Zbpack is a tool to help you analyze your project and build Docker image in one click.",
 		Long: "Zbpack is a powerful tool that not only analyzes your project for dependencies and requirements, " +
@@ -34,6 +36,7 @@ var (
 
 func init() {
 	cmd.PersistentFlags().BoolVarP(&info, "info", "i", false, "only print project information")
+	cmd.PersistentFlags().StringVar(&userSubmoduleName, "submodule", "", "submodule (service) name. by default, it is picked from the directory name.")
 	cmd.SetUsageTemplate(usageTemplate)
 }
 

--- a/internal/zbpack/zbpack.go
+++ b/internal/zbpack/zbpack.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/zeabur/zbpack/pkg/zeaburpack"
 )
@@ -95,7 +96,7 @@ func build(path string) error {
 	return zeaburpack.Build(
 		&zeaburpack.BuildOptions{
 			Path:          &path,
-			Interactive:   &trueValue,
+			Interactive:   lo.ToPtr(true),
 			SubmoduleName: &submoduleName,
 		},
 	)


### PR DESCRIPTION
- feat(cli): Allow passing --submodule <name>
- feat(cli): Print submoduleName for debugging
- refactor(cli): Use lo for pointer value
