### PR TITLE
fix: Use bun as pkg manager for Node.js provider

### DIFF
--- a/internal/bun/identify.go
+++ b/internal/bun/identify.go
@@ -31,6 +31,12 @@ func (i *identify) Match(fs afero.Fs) bool {
 		hasBunTypes = bytes.Contains(packageJSON, []byte(`"bun-types"`))
 	}
 
+	// Some developer use bun as package manager for their Next.js or Nuxt.js project.
+	// In this case, we should treat it as a Node.js project.
+	if bytes.Contains(packageJSON, []byte(`"next"`)) || bytes.Contains(packageJSON, []byte(`"nuxt"`)) {
+		return false
+	}
+
 	return hasPackageJSON && (hasBunLockfile || hasBunTypes)
 }
 

--- a/internal/nodejs/node.go
+++ b/internal/nodejs/node.go
@@ -52,7 +52,7 @@ func getContextBasedOnMeta(meta types.PlanMeta) TemplateContext {
 		OutputDir:   meta["outputDir"],
 
 		// The flag specific to planner/bun.
-		Bun: meta["bun"] == "true",
+		Bun: meta["bun"] == "true" || meta["packageManager"] == "bun",
 	}
 
 	return context

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -95,6 +95,11 @@ func DeterminePackageManager(ctx *nodePlanContext) types.NodePackageManager {
 		return pm.Unwrap()
 	}
 
+	if utils.HasFile(src, "bun.lockb") {
+		*pm = optional.Some(types.NodePackageManagerBun)
+		return pm.Unwrap()
+	}
+
 	*pm = optional.Some(types.NodePackageManagerUnknown)
 	return pm.Unwrap()
 }


### PR DESCRIPTION
# Before 💩

```
╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ bun                                                ║
║───────────────────────────────────────────────────────────────────────║
║ serverless       │ true                                               ║
║───────────────────────────────────────────────────────────────────────║
║ bun              │ true                                               ║
║───────────────────────────────────────────────────────────────────────║
║ packageManager   │ bun                                                ║
║───────────────────────────────────────────────────────────────────────║
║ framework        │ none                                               ║
║───────────────────────────────────────────────────────────────────────║
║ nodeVersion      │ 18                                                 ║
║───────────────────────────────────────────────────────────────────────║
║ installCmd       │ COPY package.json* tsconfig.json* .npmrc* .        ║
║                  │ COPY bun.lockb* .                                  ║
║                  │ RUN bun install                                    ║
║───────────────────────────────────────────────────────────────────────║
║ buildCmd         │ bun run build                                      ║
╚═══════════════════════════════════════════════════════════════════════╝
```

# After 👍

## Nuxt.js

```
❯ bunx nuxi@latest init nuxtjs-bun-template

✔ Which package manager would you like to use?
bun
◐ Installing dependencies... 
bun install v1.0.0 (822a00c4)
 + nuxt@3.9.3
 + vue@3.4.15
 + vue-router@4.2.5
✔ Types generated in .nuxt    

 677 packages installed [6.28s]
✔ Installation completed.              

✔ Initialize git repository?
Yes
ℹ Initializing git repository...           

Initialized empty Git repository in /Users/yuanlin/Developer/nuxtjs-bun-template/.git/
✨ Nuxt project has been created with the v3 template. Next steps:
 › cd nuxtjs-bun-template                                                                            
 › Start development server with bun run dev                                  
```

```
❯ cd nuxtjs-bun-template/
```

```
❯ zbpack .

╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ nodejs                                             ║
║───────────────────────────────────────────────────────────────────────║
║ packageManager   │ bun                                                ║
║───────────────────────────────────────────────────────────────────────║
║ framework        │ nuxt.js                                            ║
║───────────────────────────────────────────────────────────────────────║
║ nodeVersion      │ 18                                                 ║
║───────────────────────────────────────────────────────────────────────║
║ installCmd       │ COPY package.json* tsconfig.json* .npmrc* .        ║
║                  │ COPY bun.lockb* .                                  ║
║                  │ RUN bun install                                    ║
║───────────────────────────────────────────────────────────────────────║
║ buildCmd         │ bun run build                                      ║
║───────────────────────────────────────────────────────────────────────║
║ serverless       │ true                                               ║
╚═══════════════════════════════════════════════════════════════════════╝
```

## Next.js

```
❯ bun create next-app
✔ What is your project named? … nextjs-bun-template
✔ Would you like to use TypeScript? … No / Yes
✔ Would you like to use ESLint? … No / Yes
✔ Would you like to use Tailwind CSS? … No / Yes
✔ Would you like to use `src/` directory? … No / Yes
✔ Would you like to use App Router? (recommended) … No / Yes
✔ Would you like to customize the default import alias (@/*)? … No / Yes
Creating a new Next.js app in /Users/yuanlin/Developer/nextjs-bun-template.

Using bun.

Initializing project with template: app-tw


Installing dependencies:
- react
- react-dom
- next

Installing devDependencies:
- typescript
- @types/node
- @types/react
- @types/react-dom
- autoprefixer
- postcss
- tailwindcss

bun install v1.0.0 (822a00c4)
 + @types/node@20.11.5
 + @types/react@18.2.48
 + @types/react-dom@18.2.18
 + autoprefixer@10.4.17
 + postcss@8.4.33
 + tailwindcss@3.4.1
 + typescript@5.3.3
 + next@14.1.0
 + react@18.2.0
 + react-dom@18.2.0

 139 packages installed [5.60s]
Initialized a git repository.

Success! Created nextjs-bun-template at /Users/yuanlin/Developer/nextjs-bun-template
```

```
❯ zbpack .

╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ nodejs                                             ║
║───────────────────────────────────────────────────────────────────────║
║ serverless       │ true                                               ║
║───────────────────────────────────────────────────────────────────────║
║ packageManager   │ bun                                                ║
║───────────────────────────────────────────────────────────────────────║
║ framework        │ next.js                                            ║
║───────────────────────────────────────────────────────────────────────║
║ nodeVersion      │ 18                                                 ║
║───────────────────────────────────────────────────────────────────────║
║ installCmd       │ COPY package.json* tsconfig.json* .npmrc* .        ║
║                  │ COPY bun.lockb* .                                  ║
║                  │ RUN bun install                                    ║
║───────────────────────────────────────────────────────────────────────║
║ buildCmd         │ bun run build                                      ║
╚═══════════════════════════════════════════════════════════════════════╝
```