### PR TITLE
ZEA-2458: docker/distribution has been deprecated

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.5.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gkampitakis/ciinfo v0.3.0 // indirect
 	github.com/gkampitakis/go-diff v1.3.2 // indirect
@@ -54,7 +53,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/containerd/console v1.0.3
 	github.com/deckarep/golang-set v1.8.0
-	github.com/docker/distribution v2.8.3+incompatible
+	github.com/distribution/reference v0.5.0
 	github.com/evanw/esbuild v0.19.11
 	github.com/gkampitakis/go-snaps v0.4.12
 	github.com/google/go-github/v53 v53.2.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsP
 github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
-github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/evanw/esbuild v0.19.11 h1:mbPO1VJ/df//jjUd+p/nRLYCpizXxXb2w/zZMShxa2k=
 github.com/evanw/esbuild v0.19.11/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfVQuRi48=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/pkg/zeaburpack/ref.go
+++ b/pkg/zeaburpack/ref.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/reference"
 )
 
 // referenceConstructor constructs the standardized image references

--- a/pkg/zeaburpack/ref.go
+++ b/pkg/zeaburpack/ref.go
@@ -12,14 +12,14 @@ import (
 // a proxy registry to the image reference.
 type referenceConstructor struct {
 	// proxyRegistry indicates the registry to be used for the image.
-	// It is designed for Harbor's Proxy Cache (ref 1).
+	// It is designed for Harbor's Proxy Cache (Ref 1).
 	//
 	// It will be prepended to any image in zeaburpack. If an image
-	// contains domain in the image name, the proxy registry will not
+	// contains a domain in the image name, the proxy registry will not
 	// be applied to the image (however, if the domain is `docker.io`,
-	// it will be still replaced).
+	// it will still be replaced).
 	//
-	// (ref 1) https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/
+	// (Ref 1) https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/
 	proxyRegistry *string
 
 	// stage is a special image reference that will not be extended
@@ -67,7 +67,7 @@ func (rc *referenceConstructor) Construct(rawRefString string) string {
 		return rawRefString
 	}
 
-	// If the image reference contains domain, we don't need to
+	// If the image reference contains a domain, we don't need to
 	// apply the proxy registry (unless the domain is `docker.io`).
 	imageRef, ok := ref.(reference.Named)
 	if !ok {


### PR DESCRIPTION
- refactor(lib): Migrate docker/distribution/* to distribution/*
- style(lib): Correct sentence according to JetBrains' suggestions
