### PR TITLE
fix(planner/python): Add start command prefix to Django collectstatic

### DIFF
--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -627,6 +627,10 @@ func determineBuildCmd(ctx *pythonPlanContext) string {
 	packageManager := DeterminePackageManager(ctx)
 	staticInfo := DetermineStaticInfo(ctx)
 
+	if postInstallCmd := getPmPostInstallCmd(packageManager); postInstallCmd != "" {
+		commands += "RUN " + postInstallCmd + "\n"
+	}
+
 	if staticInfo.DjangoEnabled() {
 		prefix := getPmStartCmdPrefix(packageManager)
 		if prefix != "" {
@@ -634,10 +638,6 @@ func determineBuildCmd(ctx *pythonPlanContext) string {
 		}
 		// We need to collect static files if we are using Django.
 		commands += "RUN " + prefix + "python manage.py collectstatic --noinput\n"
-	}
-
-	if postInstallCmd := getPmPostInstallCmd(packageManager); postInstallCmd != "" {
-		commands = "RUN " + postInstallCmd + "\n"
 	}
 
 	return strings.TrimSpace(commands)

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -624,14 +624,18 @@ func determinePythonVersionWithRye(ctx *pythonPlanContext) string {
 func determineBuildCmd(ctx *pythonPlanContext) string {
 	commands := ""
 
+	packageManager := DeterminePackageManager(ctx)
 	staticInfo := DetermineStaticInfo(ctx)
 
 	if staticInfo.DjangoEnabled() {
+		prefix := getPmStartCmdPrefix(packageManager)
+		if prefix != "" {
+			prefix += " " // ex. poetry run
+		}
 		// We need to collect static files if we are using Django.
-		commands += "RUN python manage.py collectstatic --noinput\n"
+		commands += "RUN " + prefix + "python manage.py collectstatic --noinput\n"
 	}
 
-	packageManager := DeterminePackageManager(ctx)
 	if postInstallCmd := getPmPostInstallCmd(packageManager); postInstallCmd != "" {
 		commands = "RUN " + postInstallCmd + "\n"
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Add the start command prefix (`poetry run`, etc.) to `RUN python manage.py collectstatic --noinput\n`.
Also, correct the installation order for `pip install -r requirements.txt`.

I have tested both Poetry and Pip case.
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-2547<!-- Add an issue number if this PR will close it. -->
- Suggested label: bug<!-- Help us triage by suggesting one of our labels that describes your PR -->
