### PR TITLE
fix(plan/rust): Fix file missing due to rust build binary name

### DIFF
--- a/internal/rust/template.Dockerfile
+++ b/internal/rust/template.Dockerfile
@@ -58,9 +58,9 @@ RUN useradd -m -s /bin/bash zeabur
 USER zeabur
 WORKDIR /app
 
-COPY --from=builder --chown=zeabur:zeabur /app/bin/server ./bin/server
+COPY --from=builder --chown=zeabur:zeabur /app/bin/server /app/bin/server
 
-CMD ["./bin/server"]
+CMD ["/app/bin/server"]
 # {{ else }}
 FROM scratch
 COPY --from=builder /app/bin/server main


### PR DESCRIPTION
#### Description (required)

This issue fixes rust build missing binary file due to old serverless export method using fixed SubmoduleName.

#### Related issues & labels (optional)

- Closes ZEA-2557
- Suggested label: bug
