### PR TITLE
ZEA-2569: Refactor PHP extension installer

### DIFF
--- a/internal/php/__snapshots__/template_test.snap
+++ b/internal/php/__snapshots__/template_test.snap
@@ -15,6 +15,22 @@ CMD nginx; php-fpm
 
 ---
 
+[TestTemplate/7-codeigniter-nginx,owo-0 - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
 [TestTemplate/7-codeigniter-nginx,owo-1 - 1]
 FROM docker.io/library/php:7-fpm
 
@@ -30,14 +46,27 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter-nginx,owo-1 - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -75,14 +104,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -105,7 +126,39 @@ CMD nginx; php-fpm
 
 ---
 
+[TestTemplate/7-laravel-nginx,owo-0 - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
 [TestTemplate/7-laravel-nginx,owo-0+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx,owo-0+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
@@ -166,14 +219,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -195,14 +240,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -224,14 +261,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -251,14 +280,6 @@ RUN chmod +x /usr/local/bin/install-php-extensions && sync
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -342,14 +363,27 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-1 - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -371,14 +405,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -400,14 +426,27 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-1+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -427,17 +466,25 @@ RUN chmod +x /usr/local/bin/install-php-extensions && sync
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-none-nginx,owo-0 - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
 
 ---
 
@@ -472,14 +519,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -517,14 +556,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -562,14 +593,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -607,14 +630,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -652,14 +667,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -697,15 +704,23 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx,owo-0 - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 
 CMD nginx; php-fpm
 
@@ -788,14 +803,27 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx,owo-1 - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -817,14 +845,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -846,14 +866,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -873,14 +885,6 @@ RUN chmod +x /usr/local/bin/install-php-extensions && sync
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -949,6 +953,34 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
+[TestTemplate/8.1-laravel-nginx-0+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx-0+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
 [TestTemplate/8.1-laravel-nginx-1 - 1]
 FROM docker.io/library/php:8.1-fpm
 
@@ -964,14 +996,27 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-1 - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -993,14 +1038,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1022,14 +1059,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1049,14 +1078,6 @@ RUN chmod +x /usr/local/bin/install-php-extensions && sync
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -1094,14 +1115,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1139,14 +1152,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1184,14 +1189,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1229,14 +1226,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1274,14 +1263,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1319,14 +1300,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1334,6 +1307,22 @@ CMD nginx; php-fpm
 ---
 
 [TestTemplate/8.2-laravel-nginx,owo-0 - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx,owo-0+os- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
@@ -1410,14 +1399,27 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx,owo-1 - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1439,14 +1441,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1468,14 +1462,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1495,14 +1481,6 @@ RUN chmod +x /usr/local/bin/install-php-extensions && sync
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -1526,6 +1504,22 @@ CMD nginx; php-fpm
 ---
 
 [TestTemplate/8.2-laravel-nginx-0+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-0+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1586,14 +1580,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1615,14 +1601,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1644,14 +1622,27 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-1+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1671,14 +1662,6 @@ RUN chmod +x /usr/local/bin/install-php-extensions && sync
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -1716,14 +1699,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1761,15 +1736,23 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx,owo-0 - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 
 CMD nginx; php-fpm
 
@@ -1806,14 +1789,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1851,14 +1826,27 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx-1 - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1880,14 +1868,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n location / {\n     if (!-e \$request_filename){\n         rewrite ^(.*)\$ /index.php?s=\$1 last; break;\n     }\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm

--- a/internal/php/__snapshots__/template_test.snap
+++ b/internal/php/__snapshots__/template_test.snap
@@ -1,5 +1,107 @@
 
-[TestTemplate/7-codeigniter-nginx-0 - 1]
+[TestTemplate/7-codeigniter--0- - 1]
+FROM docker.io/library/php:7-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter--0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter--0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter--1- - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter--1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter--1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter-nginx-0- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -15,7 +117,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-codeigniter-nginx-1 - 1]
+[TestTemplate/7-codeigniter-nginx-0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter-nginx-1- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -33,7 +173,49 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-codeigniter-nginx_owo-0 - 1]
+[TestTemplate/7-codeigniter-nginx-1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter-nginx_owo-0- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -49,7 +231,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-codeigniter-nginx_owo-1 - 1]
+[TestTemplate/7-codeigniter-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter-nginx_owo-1- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -67,7 +287,445 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx-0 - 1]
+[TestTemplate/7-codeigniter-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-codeigniter-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0- - 1]
+FROM docker.io/library/php:7-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0-+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0-+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0-+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel--0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0-aaa+os- - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel--0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0-aaa_bbb+os- - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--0-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel--1- - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--1-+os- - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--1-+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--1-+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel--1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--1-aaa+os- - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--1-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--1-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel--1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--1-aaa_bbb+os- - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--1-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel--1-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel-nginx-0- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -83,7 +741,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx-0+os- - 1]
+[TestTemplate/7-laravel-nginx-0-+os- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -99,7 +757,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx-0+os-roadrunner - 1]
+[TestTemplate/7-laravel-nginx-0-+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -115,7 +773,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx-0+os-swoole - 1]
+[TestTemplate/7-laravel-nginx-0-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
 
@@ -129,7 +787,155 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/7-laravel-nginx-1 - 1]
+[TestTemplate/7-laravel-nginx-0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-0-aaa+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-0-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-0-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-0-aaa_bbb+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-0-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-0-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel-nginx-1- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -147,7 +953,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx-1+os- - 1]
+[TestTemplate/7-laravel-nginx-1-+os- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -165,7 +971,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx-1+os-roadrunner - 1]
+[TestTemplate/7-laravel-nginx-1-+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -183,7 +989,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx-1+os-swoole - 1]
+[TestTemplate/7-laravel-nginx-1-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
 
@@ -199,7 +1005,171 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/7-laravel-nginx_owo-0 - 1]
+[TestTemplate/7-laravel-nginx-1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-1-aaa+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-1-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-1-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-1-aaa_bbb+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-1-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx-1-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-0- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -215,7 +1185,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx_owo-0+os- - 1]
+[TestTemplate/7-laravel-nginx_owo-0-+os- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -231,7 +1201,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx_owo-0+os-roadrunner - 1]
+[TestTemplate/7-laravel-nginx_owo-0-+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -247,7 +1217,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx_owo-0+os-swoole - 1]
+[TestTemplate/7-laravel-nginx_owo-0-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
 
@@ -261,7 +1231,155 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/7-laravel-nginx_owo-1 - 1]
+[TestTemplate/7-laravel-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-0-aaa+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-0-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-0-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-0-aaa_bbb+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-0-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-0-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -279,7 +1397,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx_owo-1+os- - 1]
+[TestTemplate/7-laravel-nginx_owo-1-+os- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -297,7 +1415,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx_owo-1+os-roadrunner - 1]
+[TestTemplate/7-laravel-nginx_owo-1-+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -315,7 +1433,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx_owo-1+os-swoole - 1]
+[TestTemplate/7-laravel-nginx_owo-1-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
 
@@ -331,7 +1449,273 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/7-none-nginx-0 - 1]
+[TestTemplate/7-laravel-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1-aaa+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1-aaa_bbb+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-none--0- - 1]
+FROM docker.io/library/php:7-fpm
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none--0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none--0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none--1- - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none--1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none--1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none-nginx-0- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -347,7 +1731,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-none-nginx-1 - 1]
+[TestTemplate/7-none-nginx-0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none-nginx-1- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -365,7 +1787,49 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-none-nginx_owo-0 - 1]
+[TestTemplate/7-none-nginx-1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none-nginx_owo-0- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -381,7 +1845,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-none-nginx_owo-1 - 1]
+[TestTemplate/7-none-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none-nginx_owo-1- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -399,7 +1901,151 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-thinkphp-nginx-0 - 1]
+[TestTemplate/7-none-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-none-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp--0- - 1]
+FROM docker.io/library/php:7-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp--0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp--0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp--1- - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp--1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp--1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp-nginx-0- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -415,7 +2061,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-thinkphp-nginx-1 - 1]
+[TestTemplate/7-thinkphp-nginx-0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp-nginx-1- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -433,7 +2117,49 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-thinkphp-nginx_owo-0 - 1]
+[TestTemplate/7-thinkphp-nginx-1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp-nginx_owo-0- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -449,7 +2175,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-thinkphp-nginx_owo-1 - 1]
+[TestTemplate/7-thinkphp-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp-nginx_owo-1- - 1]
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -467,7 +2231,151 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-codeigniter-nginx-0 - 1]
+[TestTemplate/7-thinkphp-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-thinkphp-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter--0- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter--0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter--0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter--1- - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter--1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter--1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter-nginx-0- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -483,7 +2391,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-codeigniter-nginx-1 - 1]
+[TestTemplate/8.1-codeigniter-nginx-0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter-nginx-1- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -501,7 +2447,49 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-codeigniter-nginx_owo-0 - 1]
+[TestTemplate/8.1-codeigniter-nginx-1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter-nginx_owo-0- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -517,7 +2505,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-codeigniter-nginx_owo-1 - 1]
+[TestTemplate/8.1-codeigniter-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter-nginx_owo-1- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -535,7 +2561,445 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx-0 - 1]
+[TestTemplate/8.1-codeigniter-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-codeigniter-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0-+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0-+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0-+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel--0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0-aaa+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel--0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--0-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel--1- - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--1-+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--1-+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--1-+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel--1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--1-aaa+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--1-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--1-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel--1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--1-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--1-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel--1-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx-0- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -551,7 +3015,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx-0+os- - 1]
+[TestTemplate/8.1-laravel-nginx-0-+os- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -567,7 +3031,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx-0+os-roadrunner - 1]
+[TestTemplate/8.1-laravel-nginx-0-+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -583,7 +3047,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx-0+os-swoole - 1]
+[TestTemplate/8.1-laravel-nginx-0-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
 
@@ -597,7 +3061,155 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.1-laravel-nginx-1 - 1]
+[TestTemplate/8.1-laravel-nginx-0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-0-aaa+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-0-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-0-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-0-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-0-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-0-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx-1- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -615,7 +3227,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx-1+os- - 1]
+[TestTemplate/8.1-laravel-nginx-1-+os- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -633,7 +3245,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx-1+os-roadrunner - 1]
+[TestTemplate/8.1-laravel-nginx-1-+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -651,7 +3263,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx-1+os-swoole - 1]
+[TestTemplate/8.1-laravel-nginx-1-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
 
@@ -667,7 +3279,171 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.1-laravel-nginx_owo-0 - 1]
+[TestTemplate/8.1-laravel-nginx-1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-1-aaa+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-1-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-1-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-1-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-1-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx-1-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -683,7 +3459,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx_owo-0+os- - 1]
+[TestTemplate/8.1-laravel-nginx_owo-0-+os- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -699,7 +3475,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx_owo-0+os-roadrunner - 1]
+[TestTemplate/8.1-laravel-nginx_owo-0-+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -715,7 +3491,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx_owo-0+os-swoole - 1]
+[TestTemplate/8.1-laravel-nginx_owo-0-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
 
@@ -729,7 +3505,155 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.1-laravel-nginx_owo-1 - 1]
+[TestTemplate/8.1-laravel-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0-aaa+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -747,7 +3671,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx_owo-1+os- - 1]
+[TestTemplate/8.1-laravel-nginx_owo-1-+os- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -765,7 +3689,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx_owo-1+os-roadrunner - 1]
+[TestTemplate/8.1-laravel-nginx_owo-1-+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -783,7 +3707,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx_owo-1+os-swoole - 1]
+[TestTemplate/8.1-laravel-nginx_owo-1-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
 
@@ -799,7 +3723,273 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.1-none-nginx-0 - 1]
+[TestTemplate/8.1-laravel-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1-aaa+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-none--0- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none--0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none--0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none--1- - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none--1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none--1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none-nginx-0- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -815,7 +4005,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-none-nginx-1 - 1]
+[TestTemplate/8.1-none-nginx-0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none-nginx-1- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -833,7 +4061,49 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-none-nginx_owo-0 - 1]
+[TestTemplate/8.1-none-nginx-1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none-nginx_owo-0- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -849,7 +4119,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-none-nginx_owo-1 - 1]
+[TestTemplate/8.1-none-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none-nginx_owo-1- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -867,7 +4175,151 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-thinkphp-nginx-0 - 1]
+[TestTemplate/8.1-none-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-none-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp--0- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp--0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp--0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp--1- - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp--1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp--1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp-nginx-0- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -883,7 +4335,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-thinkphp-nginx-1 - 1]
+[TestTemplate/8.1-thinkphp-nginx-0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp-nginx-1- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -901,7 +4391,49 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-thinkphp-nginx_owo-0 - 1]
+[TestTemplate/8.1-thinkphp-nginx-1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp-nginx_owo-0- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -917,7 +4449,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-thinkphp-nginx_owo-1 - 1]
+[TestTemplate/8.1-thinkphp-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp-nginx_owo-1- - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -935,7 +4505,151 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-codeigniter-nginx-0 - 1]
+[TestTemplate/8.1-thinkphp-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-thinkphp-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter--0- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter--0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter--0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter--1- - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter--1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter--1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter-nginx-0- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -951,7 +4665,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-codeigniter-nginx-1 - 1]
+[TestTemplate/8.2-codeigniter-nginx-0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter-nginx-1- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -969,7 +4721,49 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-codeigniter-nginx_owo-0 - 1]
+[TestTemplate/8.2-codeigniter-nginx-1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter-nginx_owo-0- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -985,7 +4779,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-codeigniter-nginx_owo-1 - 1]
+[TestTemplate/8.2-codeigniter-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter-nginx_owo-1- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1003,7 +4835,445 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx-0 - 1]
+[TestTemplate/8.2-codeigniter-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-codeigniter-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0-+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0-+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0-+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel--0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0-aaa+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel--0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--0-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel--1- - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--1-+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--1-+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--1-+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel--1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--1-aaa+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--1-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--1-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel--1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--1-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--1-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel--1-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel-nginx-0- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1019,7 +5289,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx-0+os- - 1]
+[TestTemplate/8.2-laravel-nginx-0-+os- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1035,7 +5305,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx-0+os-roadrunner - 1]
+[TestTemplate/8.2-laravel-nginx-0-+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1051,7 +5321,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx-0+os-swoole - 1]
+[TestTemplate/8.2-laravel-nginx-0-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
 
@@ -1065,7 +5335,155 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.2-laravel-nginx-1 - 1]
+[TestTemplate/8.2-laravel-nginx-0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-0-aaa+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-0-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-0-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-0-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-0-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-0-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel-nginx-1- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1083,7 +5501,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx-1+os- - 1]
+[TestTemplate/8.2-laravel-nginx-1-+os- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1101,7 +5519,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx-1+os-roadrunner - 1]
+[TestTemplate/8.2-laravel-nginx-1-+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1119,7 +5537,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx-1+os-swoole - 1]
+[TestTemplate/8.2-laravel-nginx-1-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
 
@@ -1135,7 +5553,171 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.2-laravel-nginx_owo-0 - 1]
+[TestTemplate/8.2-laravel-nginx-1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-1-aaa+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-1-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-1-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-1-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-1-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx-1-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1151,7 +5733,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx_owo-0+os- - 1]
+[TestTemplate/8.2-laravel-nginx_owo-0-+os- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1167,7 +5749,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx_owo-0+os-roadrunner - 1]
+[TestTemplate/8.2-laravel-nginx_owo-0-+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1183,7 +5765,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx_owo-0+os-swoole - 1]
+[TestTemplate/8.2-laravel-nginx_owo-0-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
 
@@ -1197,7 +5779,155 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.2-laravel-nginx_owo-1 - 1]
+[TestTemplate/8.2-laravel-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0-aaa+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1215,7 +5945,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx_owo-1+os- - 1]
+[TestTemplate/8.2-laravel-nginx_owo-1-+os- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1233,7 +5963,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx_owo-1+os-roadrunner - 1]
+[TestTemplate/8.2-laravel-nginx_owo-1-+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1251,7 +5981,7 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx_owo-1+os-swoole - 1]
+[TestTemplate/8.2-laravel-nginx_owo-1-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
 
@@ -1267,7 +5997,273 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.2-none-nginx-0 - 1]
+[TestTemplate/8.2-laravel-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1-aaa+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1-aaa+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1-aaa+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1-aaa_bbb+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1-aaa_bbb+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1-aaa_bbb+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-none--0- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none--0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none--0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none--1- - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none--1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none--1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none-nginx-0- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1283,7 +6279,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-none-nginx-1 - 1]
+[TestTemplate/8.2-none-nginx-0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none-nginx-1- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1301,7 +6335,49 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-none-nginx_owo-0 - 1]
+[TestTemplate/8.2-none-nginx-1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none-nginx_owo-0- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1317,7 +6393,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-none-nginx_owo-1 - 1]
+[TestTemplate/8.2-none-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none-nginx_owo-1- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1335,7 +6449,151 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-thinkphp-nginx-0 - 1]
+[TestTemplate/8.2-none-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-none-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp--0- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp--0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp--0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp--1- - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp--1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp--1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx-0- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1351,7 +6609,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-thinkphp-nginx-1 - 1]
+[TestTemplate/8.2-thinkphp-nginx-0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx-1- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
@@ -1369,7 +6665,49 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-thinkphp-nginx_owo-0 - 1]
+[TestTemplate/8.2-thinkphp-nginx-1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx_owo-0- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1385,7 +6723,45 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-thinkphp-nginx_owo-1 - 1]
+[TestTemplate/8.2-thinkphp-nginx_owo-0-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx_owo-0-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx_owo-1- - 1]
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
@@ -1397,6 +6773,48 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx_owo-1-aaa - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx_owo-1-aaa_bbb - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm

--- a/internal/php/__snapshots__/template_test.snap
+++ b/internal/php/__snapshots__/template_test.snap
@@ -1,78 +1,4 @@
 
-[TestTemplate/7-codeigniter-nginx,owo-0 - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-codeigniter-nginx,owo-0 - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-codeigniter-nginx,owo-1 - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-codeigniter-nginx,owo-1 - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
 [TestTemplate/7-codeigniter-nginx-0 - 1]
 FROM docker.io/library/php:7-fpm
 
@@ -93,10 +19,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -110,10 +33,10 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx,owo-0 - 1]
+[TestTemplate/7-codeigniter-nginx_owo-0 - 1]
 FROM docker.io/library/php:7-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -126,92 +49,11 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-laravel-nginx,owo-0 - 1]
+[TestTemplate/7-codeigniter-nginx_owo-1 - 1]
 FROM docker.io/library/php:7-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-laravel-nginx,owo-0+os- - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-laravel-nginx,owo-0+os-roadrunner - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-laravel-nginx,owo-0+os-roadrunner - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-laravel-nginx,owo-0+os-swoole - 1]
-FROM docker.io/phpswoole/swoole:php7
-RUN docker-php-ext-install pcntl
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-
-CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
-
----
-
-[TestTemplate/7-laravel-nginx,owo-1 - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -222,67 +64,6 @@ RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_heade
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-laravel-nginx,owo-1+os- - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-laravel-nginx,owo-1+os-roadrunner - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-laravel-nginx,owo-1+os-swoole - 1]
-FROM docker.io/phpswoole/swoole:php7
-RUN docker-php-ext-install pcntl
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
 ---
 
@@ -352,31 +133,7 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-laravel-nginx-1 - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -394,10 +151,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -415,31 +169,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/7-laravel-nginx-1+os-roadrunner - 1]
-FROM docker.io/library/php:7-fpm
-
-RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -458,10 +188,7 @@ FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -472,13 +199,13 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/7-none-nginx,owo-0 - 1]
+[TestTemplate/7-laravel-nginx_owo-0 - 1]
 FROM docker.io/library/php:7-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
-COPY --chown=www-data:www-data . /var/www/public
-WORKDIR /var/www/public
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -488,13 +215,13 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-none-nginx,owo-0 - 1]
+[TestTemplate/7-laravel-nginx_owo-0+os- - 1]
 FROM docker.io/library/php:7-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
-COPY --chown=www-data:www-data . /var/www/public
-WORKDIR /var/www/public
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -504,17 +231,44 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-none-nginx,owo-1 - 1]
+[TestTemplate/7-laravel-nginx_owo-0+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-0+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1 - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
-COPY --chown=www-data:www-data . /var/www/public
-WORKDIR /var/www/public
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -522,6 +276,58 @@ RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_heade
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1+os- - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1+os-roadrunner - 1]
+FROM docker.io/library/php:7-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/7-laravel-nginx_owo-1+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php7
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
 ---
 
@@ -545,10 +351,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -562,13 +365,13 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-thinkphp-nginx,owo-0 - 1]
+[TestTemplate/7-none-nginx_owo-0 - 1]
 FROM docker.io/library/php:7-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -578,17 +381,14 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/7-thinkphp-nginx,owo-1 - 1]
+[TestTemplate/7-none-nginx_owo-1 - 1]
 FROM docker.io/library/php:7-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -619,10 +419,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:7-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -636,10 +433,10 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-codeigniter-nginx,owo-0 - 1]
-FROM docker.io/library/php:8.1-fpm
+[TestTemplate/7-thinkphp-nginx_owo-0 - 1]
+FROM docker.io/library/php:7-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -652,14 +449,11 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-codeigniter-nginx,owo-1 - 1]
-FROM docker.io/library/php:8.1-fpm
+[TestTemplate/7-thinkphp-nginx_owo-1 - 1]
+FROM docker.io/library/php:7-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -693,10 +487,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -710,10 +501,10 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx,owo-0 - 1]
+[TestTemplate/8.1-codeigniter-nginx_owo-0 - 1]
 FROM docker.io/library/php:8.1-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -726,76 +517,11 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-laravel-nginx,owo-0 - 1]
+[TestTemplate/8.1-codeigniter-nginx_owo-1 - 1]
 FROM docker.io/library/php:8.1-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.1-laravel-nginx,owo-0+os- - 1]
-FROM docker.io/library/php:8.1-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.1-laravel-nginx,owo-0+os-roadrunner - 1]
-FROM docker.io/library/php:8.1-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.1-laravel-nginx,owo-0+os-swoole - 1]
-FROM docker.io/phpswoole/swoole:php8.1
-RUN docker-php-ext-install pcntl
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-
-CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
-
----
-
-[TestTemplate/8.1-laravel-nginx,owo-1 - 1]
-FROM docker.io/library/php:8.1-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -806,88 +532,6 @@ RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_heade
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.1-laravel-nginx,owo-1 - 1]
-FROM docker.io/library/php:8.1-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.1-laravel-nginx,owo-1+os- - 1]
-FROM docker.io/library/php:8.1-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.1-laravel-nginx,owo-1+os-roadrunner - 1]
-FROM docker.io/library/php:8.1-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.1-laravel-nginx,owo-1+os-swoole - 1]
-FROM docker.io/phpswoole/swoole:php8.1
-RUN docker-php-ext-install pcntl
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
 ---
 
@@ -953,63 +597,11 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.1-laravel-nginx-0+os-swoole - 1]
-FROM docker.io/phpswoole/swoole:php8.1
-RUN docker-php-ext-install pcntl
-
-RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-
-CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
-
----
-
-[TestTemplate/8.1-laravel-nginx-0+os-swoole - 1]
-FROM docker.io/phpswoole/swoole:php8.1
-RUN docker-php-ext-install pcntl
-
-RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-
-CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
-
----
-
 [TestTemplate/8.1-laravel-nginx-1 - 1]
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.1-laravel-nginx-1 - 1]
-FROM docker.io/library/php:8.1-fpm
-
-RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1027,10 +619,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1048,10 +637,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1070,10 +656,7 @@ FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1084,13 +667,13 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.1-none-nginx,owo-0 - 1]
+[TestTemplate/8.1-laravel-nginx_owo-0 - 1]
 FROM docker.io/library/php:8.1-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
-COPY --chown=www-data:www-data . /var/www/public
-WORKDIR /var/www/public
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -1100,17 +683,60 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-none-nginx,owo-1 - 1]
+[TestTemplate/8.1-laravel-nginx_owo-0+os- - 1]
 FROM docker.io/library/php:8.1-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-0+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1 - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
-COPY --chown=www-data:www-data . /var/www/public
-WORKDIR /var/www/public
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -1118,6 +744,58 @@ RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_heade
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1+os- - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1+os-roadrunner - 1]
+FROM docker.io/library/php:8.1-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.1-laravel-nginx_owo-1+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.1
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
 ---
 
@@ -1141,10 +819,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1158,13 +833,13 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-thinkphp-nginx,owo-0 - 1]
+[TestTemplate/8.1-none-nginx_owo-0 - 1]
 FROM docker.io/library/php:8.1-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -1174,17 +849,14 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.1-thinkphp-nginx,owo-1 - 1]
+[TestTemplate/8.1-none-nginx_owo-1 - 1]
 FROM docker.io/library/php:8.1-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -1215,10 +887,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.1-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1232,10 +901,10 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-codeigniter-nginx,owo-0 - 1]
-FROM docker.io/library/php:8.2-fpm
+[TestTemplate/8.1-thinkphp-nginx_owo-0 - 1]
+FROM docker.io/library/php:8.1-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1248,14 +917,11 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-codeigniter-nginx,owo-1 - 1]
-FROM docker.io/library/php:8.2-fpm
+[TestTemplate/8.1-thinkphp-nginx_owo-1 - 1]
+FROM docker.io/library/php:8.1-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1289,10 +955,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1306,10 +969,10 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx,owo-0 - 1]
+[TestTemplate/8.2-codeigniter-nginx_owo-0 - 1]
 FROM docker.io/library/php:8.2-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1322,76 +985,11 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx,owo-0+os- - 1]
+[TestTemplate/8.2-codeigniter-nginx_owo-1 - 1]
 FROM docker.io/library/php:8.2-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.2-laravel-nginx,owo-0+os- - 1]
-FROM docker.io/library/php:8.2-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.2-laravel-nginx,owo-0+os-roadrunner - 1]
-FROM docker.io/library/php:8.2-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.2-laravel-nginx,owo-0+os-swoole - 1]
-FROM docker.io/phpswoole/swoole:php8.2
-RUN docker-php-ext-install pcntl
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-
-CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
-
----
-
-[TestTemplate/8.2-laravel-nginx,owo-1 - 1]
-FROM docker.io/library/php:8.2-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1402,88 +1000,6 @@ RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_heade
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.2-laravel-nginx,owo-1 - 1]
-FROM docker.io/library/php:8.2-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.2-laravel-nginx,owo-1+os- - 1]
-FROM docker.io/library/php:8.2-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.2-laravel-nginx,owo-1+os-roadrunner - 1]
-FROM docker.io/library/php:8.2-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.2-laravel-nginx,owo-1+os-swoole - 1]
-FROM docker.io/phpswoole/swoole:php8.2
-RUN docker-php-ext-install pcntl
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
 ---
 
@@ -1535,22 +1051,6 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-laravel-nginx-0+os-roadrunner - 1]
-FROM docker.io/library/php:8.2-fpm
-
-RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
 [TestTemplate/8.2-laravel-nginx-0+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
@@ -1569,10 +1069,7 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1590,10 +1087,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1611,31 +1105,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-RUN composer install --optimize-autoloader --no-dev
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.2-laravel-nginx-1+os-roadrunner - 1]
-FROM docker.io/library/php:8.2-fpm
-
-RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1654,10 +1124,7 @@ FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1668,13 +1135,13 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 ---
 
-[TestTemplate/8.2-none-nginx,owo-0 - 1]
+[TestTemplate/8.2-laravel-nginx_owo-0 - 1]
 FROM docker.io/library/php:8.2-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
-COPY --chown=www-data:www-data . /var/www/public
-WORKDIR /var/www/public
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -1684,17 +1151,60 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-none-nginx,owo-1 - 1]
+[TestTemplate/8.2-laravel-nginx_owo-0+os- - 1]
 FROM docker.io/library/php:8.2-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-0+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1 - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
-COPY --chown=www-data:www-data . /var/www/public
-WORKDIR /var/www/public
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -1702,6 +1212,58 @@ RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_heade
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1+os- - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1+os-roadrunner - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-laravel-nginx_owo-1+os-swoole - 1]
+FROM docker.io/phpswoole/swoole:php8.2
+RUN docker-php-ext-install pcntl
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN composer install --optimize-autoloader --no-dev
+
+CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
 ---
 
@@ -1725,10 +1287,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1742,13 +1301,13 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-thinkphp-nginx,owo-0 - 1]
+[TestTemplate/8.2-none-nginx_owo-0 - 1]
 FROM docker.io/library/php:8.2-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -1758,33 +1317,14 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-thinkphp-nginx,owo-0 - 1]
+[TestTemplate/8.2-none-nginx_owo-1 - 1]
 FROM docker.io/library/php:8.2-fpm
 
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
-
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
-
-
-CMD nginx; php-fpm
-
----
-
-[TestTemplate/8.2-thinkphp-nginx,owo-1 - 1]
-FROM docker.io/library/php:8.2-fpm
-
-RUN apt-get update && apt-get install -y nginx,owo && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
-COPY --chown=www-data:www-data . /var/www
-WORKDIR /var/www
+COPY --chown=www-data:www-data . /var/www/public
+WORKDIR /var/www/public
 
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
@@ -1815,10 +1355,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1832,14 +1369,27 @@ CMD nginx; php-fpm
 
 ---
 
-[TestTemplate/8.2-thinkphp-nginx-1 - 1]
+[TestTemplate/8.2-thinkphp-nginx_owo-0 - 1]
 FROM docker.io/library/php:8.2-fpm
 
-RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 
+COPY --chown=www-data:www-data . /var/www
+WORKDIR /var/www
+
+RUN rm /etc/nginx/sites-enabled/default
+RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
+
+
+CMD nginx; php-fpm
+
+---
+
+[TestTemplate/8.2-thinkphp-nginx_owo-1 - 1]
+FROM docker.io/library/php:8.2-fpm
+
+RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1857,10 +1407,7 @@ CMD nginx; php-fpm
 FROM docker.io/library/php:8.2-fpm
 
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-RUN chmod +x /usr/local/bin/install-php-extensions && sync
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www

--- a/internal/php/__snapshots__/template_test.snap
+++ b/internal/php/__snapshots__/template_test.snap
@@ -2,6 +2,7 @@
 [TestTemplate/7-codeigniter--0- - 1]
 FROM docker.io/library/php:7-fpm
 
+
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
@@ -15,8 +16,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-codeigniter--0-aaa - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -24,7 +27,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -32,8 +34,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-codeigniter--0-aaa_bbb - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -41,7 +45,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -49,6 +52,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-codeigniter--1- - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -65,9 +69,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-codeigniter--1-aaa - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -75,7 +81,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -84,9 +89,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-codeigniter--1-aaa_bbb - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -94,7 +101,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -123,6 +129,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -130,7 +137,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -142,6 +148,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -149,7 +156,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -180,6 +186,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -187,7 +194,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -201,6 +207,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -208,7 +215,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -237,6 +243,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -244,7 +251,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -256,6 +262,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -263,7 +270,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -294,6 +300,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -301,7 +308,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -315,6 +321,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -322,7 +329,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -331,6 +337,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--0- - 1]
 FROM docker.io/library/php:7-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -346,6 +353,7 @@ CMD nginx; php-fpm
 [TestTemplate/7-laravel--0-+os- - 1]
 FROM docker.io/library/php:7-fpm
 
+
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
@@ -359,6 +367,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--0-+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -375,6 +384,7 @@ CMD nginx; php-fpm
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
 
+
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
@@ -385,8 +395,10 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/7-laravel--0-aaa - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -394,7 +406,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -402,8 +413,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--0-aaa+os- - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -411,7 +424,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -419,8 +431,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--0-aaa+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -428,7 +442,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -437,13 +450,14 @@ CMD nginx; php-fpm
 [TestTemplate/7-laravel--0-aaa+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -451,8 +465,10 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/7-laravel--0-aaa_bbb - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -460,7 +476,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -468,8 +483,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--0-aaa_bbb+os- - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -477,7 +494,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -485,8 +501,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--0-aaa_bbb+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -494,7 +512,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -503,13 +520,14 @@ CMD nginx; php-fpm
 [TestTemplate/7-laravel--0-aaa_bbb+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -517,6 +535,7 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/7-laravel--1- - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -533,6 +552,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--1-+os- - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -549,6 +569,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--1-+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -566,6 +587,7 @@ CMD nginx; php-fpm
 [TestTemplate/7-laravel--1-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -579,9 +601,11 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/7-laravel--1-aaa - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -589,7 +613,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -598,9 +621,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--1-aaa+os- - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -608,7 +633,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -617,9 +641,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--1-aaa+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -627,7 +653,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -637,14 +662,15 @@ CMD nginx; php-fpm
 [TestTemplate/7-laravel--1-aaa+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -653,9 +679,11 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/7-laravel--1-aaa_bbb - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -663,7 +691,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -672,9 +699,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--1-aaa_bbb+os- - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -682,7 +711,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -691,9 +719,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-laravel--1-aaa_bbb+os-roadrunner - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -701,7 +731,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -711,14 +740,15 @@ CMD nginx; php-fpm
 [TestTemplate/7-laravel--1-aaa_bbb+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php7
 RUN docker-php-ext-install pcntl
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -793,6 +823,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -800,7 +831,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -812,6 +842,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -819,7 +850,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -831,6 +861,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -838,7 +869,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -851,11 +881,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -867,6 +897,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -874,7 +905,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -886,6 +916,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -893,7 +924,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -905,6 +935,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -912,7 +943,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -925,11 +955,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -1012,6 +1042,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1019,7 +1050,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1033,6 +1063,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1040,7 +1071,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1054,6 +1084,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1061,7 +1092,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1076,11 +1106,11 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -1094,6 +1124,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1101,7 +1132,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1115,6 +1145,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1122,7 +1153,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1136,6 +1166,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1143,7 +1174,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1158,11 +1188,11 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -1237,6 +1267,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1244,7 +1275,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -1256,6 +1286,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1263,7 +1294,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -1275,6 +1305,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1282,7 +1313,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -1295,11 +1325,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -1311,6 +1341,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1318,7 +1349,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -1330,6 +1360,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1337,7 +1368,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -1349,6 +1379,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1356,7 +1387,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -1369,11 +1399,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -1456,6 +1486,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1463,7 +1494,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1477,6 +1507,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1484,7 +1515,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1498,6 +1528,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1505,7 +1536,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1520,11 +1550,11 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -1538,6 +1568,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1545,7 +1576,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1559,6 +1589,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1566,7 +1597,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1580,6 +1610,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1587,7 +1618,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1602,11 +1632,11 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -1615,6 +1645,7 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/7-none--0- - 1]
 FROM docker.io/library/php:7-fpm
+
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1629,8 +1660,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-none--0-aaa - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1638,7 +1671,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -1646,8 +1678,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-none--0-aaa_bbb - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1655,7 +1689,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -1663,6 +1696,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-none--1- - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www/public
@@ -1679,9 +1713,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-none--1-aaa - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1689,7 +1725,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1698,9 +1733,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-none--1-aaa_bbb - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1708,7 +1745,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1737,6 +1773,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1744,7 +1781,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -1756,6 +1792,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1763,7 +1800,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -1794,6 +1830,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1801,7 +1838,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1815,6 +1851,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1822,7 +1859,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1851,6 +1887,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1858,7 +1895,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -1870,6 +1906,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1877,7 +1914,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -1908,6 +1944,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1915,7 +1952,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1929,6 +1965,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1936,7 +1973,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -1945,6 +1981,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-thinkphp--0- - 1]
 FROM docker.io/library/php:7-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1959,8 +1996,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-thinkphp--0-aaa - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1968,7 +2007,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -1976,8 +2014,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-thinkphp--0-aaa_bbb - 1]
 FROM docker.io/library/php:7-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1985,7 +2025,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -1993,6 +2032,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-thinkphp--1- - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -2009,9 +2049,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-thinkphp--1-aaa - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2019,7 +2061,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2028,9 +2069,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/7-thinkphp--1-aaa_bbb - 1]
 FROM docker.io/library/php:7-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2038,7 +2081,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2067,6 +2109,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2074,7 +2117,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -2086,6 +2128,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2093,7 +2136,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -2124,6 +2166,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2131,7 +2174,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2145,6 +2187,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2152,7 +2195,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2181,6 +2223,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2188,7 +2231,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -2200,6 +2242,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2207,7 +2250,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -2238,6 +2280,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2245,7 +2288,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2259,6 +2301,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2266,7 +2309,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2275,6 +2317,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-codeigniter--0- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2289,8 +2332,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-codeigniter--0-aaa - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2298,7 +2343,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -2306,8 +2350,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-codeigniter--0-aaa_bbb - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2315,7 +2361,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -2323,6 +2368,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-codeigniter--1- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -2339,9 +2385,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-codeigniter--1-aaa - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2349,7 +2397,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2358,9 +2405,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-codeigniter--1-aaa_bbb - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2368,7 +2417,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2397,6 +2445,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2404,7 +2453,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -2416,6 +2464,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2423,7 +2472,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -2454,6 +2502,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2461,7 +2510,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2475,6 +2523,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2482,7 +2531,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2511,6 +2559,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2518,7 +2567,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -2530,6 +2578,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2537,7 +2586,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -2568,6 +2616,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2575,7 +2624,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2589,6 +2637,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2596,7 +2645,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2605,6 +2653,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--0- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2620,6 +2669,7 @@ CMD nginx; php-fpm
 [TestTemplate/8.1-laravel--0-+os- - 1]
 FROM docker.io/library/php:8.1-fpm
 
+
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
@@ -2633,6 +2683,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--0-+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2649,6 +2700,7 @@ CMD nginx; php-fpm
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
 
+
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
@@ -2659,8 +2711,10 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.1-laravel--0-aaa - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2668,7 +2722,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -2676,8 +2729,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--0-aaa+os- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2685,7 +2740,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -2693,8 +2747,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--0-aaa+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2702,7 +2758,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -2711,13 +2766,14 @@ CMD nginx; php-fpm
 [TestTemplate/8.1-laravel--0-aaa+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -2725,8 +2781,10 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.1-laravel--0-aaa_bbb - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2734,7 +2792,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -2742,8 +2799,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--0-aaa_bbb+os- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2751,7 +2810,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -2759,8 +2817,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--0-aaa_bbb+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2768,7 +2828,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -2777,13 +2836,14 @@ CMD nginx; php-fpm
 [TestTemplate/8.1-laravel--0-aaa_bbb+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -2791,6 +2851,7 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.1-laravel--1- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -2807,6 +2868,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--1-+os- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -2823,6 +2885,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--1-+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -2840,6 +2903,7 @@ CMD nginx; php-fpm
 [TestTemplate/8.1-laravel--1-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -2853,9 +2917,11 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.1-laravel--1-aaa - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2863,7 +2929,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2872,9 +2937,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--1-aaa+os- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2882,7 +2949,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2891,9 +2957,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--1-aaa+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2901,7 +2969,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2911,14 +2978,15 @@ CMD nginx; php-fpm
 [TestTemplate/8.1-laravel--1-aaa+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -2927,9 +2995,11 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.1-laravel--1-aaa_bbb - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2937,7 +3007,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2946,9 +3015,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--1-aaa_bbb+os- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2956,7 +3027,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2965,9 +3035,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-laravel--1-aaa_bbb+os-roadrunner - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2975,7 +3047,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -2985,14 +3056,15 @@ CMD nginx; php-fpm
 [TestTemplate/8.1-laravel--1-aaa_bbb+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.1
 RUN docker-php-ext-install pcntl
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -3067,6 +3139,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3074,7 +3147,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -3086,6 +3158,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3093,7 +3166,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -3105,6 +3177,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3112,7 +3185,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -3125,11 +3197,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -3141,6 +3213,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3148,7 +3221,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -3160,6 +3232,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3167,7 +3240,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -3179,6 +3251,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3186,7 +3259,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -3199,11 +3271,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -3286,6 +3358,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3293,7 +3366,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3307,6 +3379,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3314,7 +3387,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3328,6 +3400,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3335,7 +3408,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3350,11 +3422,11 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -3368,6 +3440,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3375,7 +3448,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3389,6 +3461,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3396,7 +3469,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3410,6 +3482,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3417,7 +3490,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3432,11 +3504,11 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -3511,6 +3583,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3518,7 +3591,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -3530,6 +3602,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3537,7 +3610,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -3549,6 +3621,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3556,7 +3629,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -3569,11 +3641,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -3585,6 +3657,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3592,7 +3665,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -3604,6 +3676,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3611,7 +3684,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -3623,6 +3695,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3630,7 +3703,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -3643,11 +3715,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -3730,6 +3802,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3737,7 +3810,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3751,6 +3823,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3758,7 +3831,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3772,6 +3844,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3779,7 +3852,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3794,11 +3866,11 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -3812,6 +3884,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3819,7 +3892,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3833,6 +3905,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3840,7 +3913,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3854,6 +3926,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3861,7 +3934,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3876,11 +3948,11 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -3889,6 +3961,7 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.1-none--0- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -3903,8 +3976,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-none--0-aaa - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -3912,7 +3987,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -3920,8 +3994,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-none--0-aaa_bbb - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -3929,7 +4005,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -3937,6 +4012,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-none--1- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www/public
@@ -3953,9 +4029,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-none--1-aaa - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -3963,7 +4041,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -3972,9 +4049,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-none--1-aaa_bbb - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -3982,7 +4061,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4011,6 +4089,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4018,7 +4097,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4030,6 +4108,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4037,7 +4116,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -4068,6 +4146,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4075,7 +4154,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4089,6 +4167,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4096,7 +4175,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4125,6 +4203,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4132,7 +4211,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4144,6 +4222,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4151,7 +4230,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -4182,6 +4260,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4189,7 +4268,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4203,6 +4281,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4210,7 +4289,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4219,6 +4297,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-thinkphp--0- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4233,8 +4312,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-thinkphp--0-aaa - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4242,7 +4323,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4250,8 +4330,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-thinkphp--0-aaa_bbb - 1]
 FROM docker.io/library/php:8.1-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4259,7 +4341,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -4267,6 +4348,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-thinkphp--1- - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -4283,9 +4365,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-thinkphp--1-aaa - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4293,7 +4377,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4302,9 +4385,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.1-thinkphp--1-aaa_bbb - 1]
 FROM docker.io/library/php:8.1-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4312,7 +4397,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4341,6 +4425,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4348,7 +4433,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4360,6 +4444,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4367,7 +4452,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -4398,6 +4482,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4405,7 +4490,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4419,6 +4503,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4426,7 +4511,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4455,6 +4539,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4462,7 +4547,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4474,6 +4558,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4481,7 +4566,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -4512,6 +4596,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4519,7 +4604,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4533,6 +4617,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4540,7 +4625,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4549,6 +4633,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-codeigniter--0- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4563,8 +4648,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-codeigniter--0-aaa - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4572,7 +4659,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4580,8 +4666,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-codeigniter--0-aaa_bbb - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4589,7 +4677,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -4597,6 +4684,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-codeigniter--1- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -4613,9 +4701,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-codeigniter--1-aaa - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4623,7 +4713,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4632,9 +4721,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-codeigniter--1-aaa_bbb - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4642,7 +4733,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4671,6 +4761,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4678,7 +4769,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4690,6 +4780,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4697,7 +4788,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -4728,6 +4818,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4735,7 +4826,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4749,6 +4839,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4756,7 +4847,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4785,6 +4875,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4792,7 +4883,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4804,6 +4894,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4811,7 +4902,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -4842,6 +4932,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4849,7 +4940,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4863,6 +4953,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4870,7 +4961,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -4879,6 +4969,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--0- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4894,6 +4985,7 @@ CMD nginx; php-fpm
 [TestTemplate/8.2-laravel--0-+os- - 1]
 FROM docker.io/library/php:8.2-fpm
 
+
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
@@ -4907,6 +4999,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--0-+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4923,6 +5016,7 @@ CMD nginx; php-fpm
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
 
+
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
@@ -4933,8 +5027,10 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.2-laravel--0-aaa - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4942,7 +5038,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4950,8 +5045,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--0-aaa+os- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4959,7 +5056,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4967,8 +5063,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--0-aaa+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4976,7 +5074,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -4985,13 +5082,14 @@ CMD nginx; php-fpm
 [TestTemplate/8.2-laravel--0-aaa+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -4999,8 +5097,10 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.2-laravel--0-aaa_bbb - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5008,7 +5108,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -5016,8 +5115,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--0-aaa_bbb+os- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5025,7 +5126,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -5033,8 +5133,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--0-aaa_bbb+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5042,7 +5144,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -5051,13 +5152,14 @@ CMD nginx; php-fpm
 [TestTemplate/8.2-laravel--0-aaa_bbb+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -5065,6 +5167,7 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.2-laravel--1- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -5081,6 +5184,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--1-+os- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -5097,6 +5201,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--1-+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -5114,6 +5219,7 @@ CMD nginx; php-fpm
 [TestTemplate/8.2-laravel--1-+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -5127,9 +5233,11 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.2-laravel--1-aaa - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5137,7 +5245,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5146,9 +5253,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--1-aaa+os- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5156,7 +5265,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5165,9 +5273,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--1-aaa+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5175,7 +5285,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5185,14 +5294,15 @@ CMD nginx; php-fpm
 [TestTemplate/8.2-laravel--1-aaa+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -5201,9 +5311,11 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.2-laravel--1-aaa_bbb - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5211,7 +5323,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5220,9 +5331,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--1-aaa_bbb+os- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5230,7 +5343,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5239,9 +5351,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-laravel--1-aaa_bbb+os-roadrunner - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5249,7 +5363,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5259,14 +5372,15 @@ CMD nginx; php-fpm
 [TestTemplate/8.2-laravel--1-aaa_bbb+os-swoole - 1]
 FROM docker.io/phpswoole/swoole:php8.2
 RUN docker-php-ext-install pcntl
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -5341,6 +5455,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5348,7 +5463,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -5360,6 +5474,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5367,7 +5482,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -5379,6 +5493,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5386,7 +5501,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -5399,11 +5513,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -5415,6 +5529,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5422,7 +5537,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -5434,6 +5548,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5441,7 +5556,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -5453,6 +5567,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5460,7 +5575,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -5473,11 +5587,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -5560,6 +5674,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5567,7 +5682,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5581,6 +5695,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5588,7 +5703,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5602,6 +5716,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5609,7 +5724,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5624,11 +5738,11 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -5642,6 +5756,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5649,7 +5764,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5663,6 +5777,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5670,7 +5785,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5684,6 +5798,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5691,7 +5806,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -5706,11 +5820,11 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -5785,6 +5899,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5792,7 +5907,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -5804,6 +5918,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5811,7 +5926,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -5823,6 +5937,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5830,7 +5945,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -5843,11 +5957,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -5859,6 +5973,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5866,7 +5981,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -5878,6 +5992,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5885,7 +6000,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -5897,6 +6011,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5904,7 +6019,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -5917,11 +6031,11 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
 
@@ -6004,6 +6118,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6011,7 +6126,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6025,6 +6139,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6032,7 +6147,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6046,6 +6160,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6053,7 +6168,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6068,11 +6182,11 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -6086,6 +6200,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6093,7 +6208,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6107,6 +6221,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6114,7 +6229,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6128,6 +6242,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6135,7 +6250,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6150,11 +6264,11 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--port=8080"]
@@ -6163,6 +6277,7 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 
 [TestTemplate/8.2-none--0- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6177,8 +6292,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-none--0-aaa - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6186,7 +6303,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -6194,8 +6310,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-none--0-aaa_bbb - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6203,7 +6321,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -6211,6 +6328,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-none--1- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www/public
@@ -6227,9 +6345,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-none--1-aaa - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6237,7 +6357,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6246,9 +6365,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-none--1-aaa_bbb - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6256,7 +6377,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6285,6 +6405,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6292,7 +6413,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -6304,6 +6424,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6311,7 +6432,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -6342,6 +6462,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6349,7 +6470,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6363,6 +6483,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6370,7 +6491,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6399,6 +6519,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6406,7 +6527,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -6418,6 +6538,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6425,7 +6546,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -6456,6 +6576,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6463,7 +6584,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6477,6 +6597,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6484,7 +6605,6 @@ WORKDIR /var/www/public
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6493,6 +6613,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-thinkphp--0- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6507,8 +6628,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-thinkphp--0-aaa - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6516,7 +6639,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -6524,8 +6646,10 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-thinkphp--0-aaa_bbb - 1]
 FROM docker.io/library/php:8.2-fpm
+
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6533,7 +6657,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -6541,6 +6664,7 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-thinkphp--1- - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 COPY --chown=www-data:www-data . /var/www
@@ -6557,9 +6681,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-thinkphp--1-aaa - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6567,7 +6693,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6576,9 +6701,11 @@ CMD nginx; php-fpm
 
 [TestTemplate/8.2-thinkphp--1-aaa_bbb - 1]
 FROM docker.io/library/php:8.2-fpm
+
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6586,7 +6713,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6615,6 +6741,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6622,7 +6749,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -6634,6 +6760,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6641,7 +6768,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -6672,6 +6798,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6679,7 +6806,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6693,6 +6819,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6700,7 +6827,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6729,6 +6855,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6736,7 +6863,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 
 CMD nginx; php-fpm
 
@@ -6748,6 +6874,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6755,7 +6882,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 
 CMD nginx; php-fpm
 
@@ -6786,6 +6912,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6793,7 +6920,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm
@@ -6807,6 +6933,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN docker-php-ext-install aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6814,7 +6941,6 @@ WORKDIR /var/www
 RUN rm /etc/nginx/sites-enabled/default
 RUN echo "server {\n    listen 8080;\n    root /var/www/public;\n\n    add_header X-Frame-Options "SAMEORIGIN";\n    add_header X-Content-Type-Options "nosniff";\n\n    index index.php index.html;\n    charset utf-8;\n\n    location = /favicon.ico { access_log off; log_not_found off; }\n    location = /robots.txt  { access_log off; log_not_found off; }\n\n    error_page 404 /index.php;\n\n    location ~ \.php\$ {\n        try_files \$uri =404;\n        fastcgi_split_path_info ^(.+\.php)(/.+)\$;\n        fastcgi_pass 127.0.0.1:9000;\n        fastcgi_index index.php;\n        include fastcgi_params;\n        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n        fastcgi_param PATH_INFO \$fastcgi_path_info;\n        fastcgi_buffering off;\n    }\n\n    location / {\n        try_files \$uri \$uri/ /index.php?\$query_string;\n        gzip_static on;\n }\n\n    location ~ /\.(?!well-known).* {\n        deny all;\n    }\n}\n" >> /etc/nginx/sites-enabled/default
 
-RUN docker-php-ext-install aaa bbb
 RUN composer install --optimize-autoloader --no-dev
 
 CMD nginx; php-fpm

--- a/internal/php/identify.go
+++ b/internal/php/identify.go
@@ -34,6 +34,7 @@ func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
 	framework := DetermineProjectFramework(options.Source)
 	phpVersion := GetPHPVersion(options.Source)
 	deps := DetermineAptDependencies(options.Source, server)
+	exts := DeterminePHPExtensions(options.Source)
 	app, property := DetermineApplication(options.Source)
 
 	// Some meta will be added to the plan dynamically later.
@@ -41,6 +42,7 @@ func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
 		"framework":  string(framework),
 		"phpVersion": phpVersion,
 		"deps":       strings.Join(deps, " "),
+		"exts":       strings.Join(exts, " "),
 		"app":        string(app),
 		"property":   PropertyToString(property),
 	}

--- a/internal/php/php.go
+++ b/internal/php/php.go
@@ -64,13 +64,13 @@ RUN echo "` + nginxConf + `" >> /etc/nginx/sites-enabled/default
 `
 	}
 
-	// install dependencies with composer
-	composerInstallCmd := "\n"
+	// install dependencies
+	installCmd := "\n"
+	if meta["exts"] != "" {
+		installCmd += `RUN docker-php-ext-install ` + meta["exts"] + "\n"
+	}
 	if projectProperty&types.PHPPropertyComposer != 0 {
-		if meta["exts"] != "" {
-			composerInstallCmd += `RUN docker-php-ext-install ` + meta["exts"] + "\n"
-		}
-		composerInstallCmd += `RUN composer install --optimize-autoloader --no-dev` + "\n"
+		installCmd += `RUN composer install --optimize-autoloader --no-dev` + "\n"
 	}
 
 	startCmd := `
@@ -86,7 +86,7 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 	dockerFile := getPhpImage +
 		installCMD +
 		copyCommand +
-		composerInstallCmd +
+		installCmd +
 		startCmd
 
 	return dockerFile, nil

--- a/internal/php/php.go
+++ b/internal/php/php.go
@@ -26,9 +26,12 @@ func GenerateDockerfile(meta types.PlanMeta) (string, error) {
 		serverMode = "swoole"
 	}
 
-	installCMD := fmt.Sprintf(`
+	installCMD := ""
+	if meta["deps"] != "" {
+		installCMD += fmt.Sprintf(`
 RUN apt-get update && apt-get install -y %s && rm -rf /var/lib/apt/lists/*
 `, meta["deps"])
+	}
 	if projectProperty&types.PHPPropertyComposer != 0 {
 		installCMD += "RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer\n"
 	}

--- a/internal/php/php.go
+++ b/internal/php/php.go
@@ -30,9 +30,10 @@ func GenerateDockerfile(meta types.PlanMeta) (string, error) {
 RUN apt-get update && apt-get install -y %s && rm -rf /var/lib/apt/lists/*
 `, meta["deps"])
 	if projectProperty&types.PHPPropertyComposer != 0 {
-		installCMD += `
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+		installCMD += "RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer\n"
+	}
+	if meta["exts"] != "" {
+		installCMD += `ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
 `
 	}

--- a/internal/php/php.go
+++ b/internal/php/php.go
@@ -66,17 +66,10 @@ RUN echo "` + nginxConf + `" >> /etc/nginx/sites-enabled/default
 	// install dependencies with composer
 	composerInstallCmd := "\n"
 	if projectProperty&types.PHPPropertyComposer != 0 {
-		composerInstallCmd = `
-RUN  echo '#!/bin/sh\n\
-extensions=$(cat composer.json | jq -r ".require | to_entries[] | select(.key | startswith(\"ext-\")) | .key[4:]")\n\
-for ext in $extensions; do\n\
-    echo "Installing PHP extension: $ext"\n\
-    docker-php-ext-install $ext\n\
-done' > /usr/local/bin/install_php_extensions.sh \
-    && chmod +x /usr/local/bin/install_php_extensions.sh \
-    && /usr/local/bin/install_php_extensions.sh
-RUN composer install --optimize-autoloader --no-dev
-`
+		if meta["exts"] != "" {
+			composerInstallCmd += `RUN docker-php-ext-install ` + meta["exts"] + "\n"
+		}
+		composerInstallCmd += `RUN composer install --optimize-autoloader --no-dev` + "\n"
 	}
 
 	startCmd := `

--- a/internal/php/php.go
+++ b/internal/php/php.go
@@ -26,19 +26,18 @@ func GenerateDockerfile(meta types.PlanMeta) (string, error) {
 		serverMode = "swoole"
 	}
 
-	installCMD := ""
+	environmentInstallCmd := "\n"
 	if meta["deps"] != "" {
-		installCMD += fmt.Sprintf(`
-RUN apt-get update && apt-get install -y %s && rm -rf /var/lib/apt/lists/*
+		environmentInstallCmd += fmt.Sprintf(`RUN apt-get update && apt-get install -y %s && rm -rf /var/lib/apt/lists/*
 `, meta["deps"])
 	}
 	if projectProperty&types.PHPPropertyComposer != 0 {
-		installCMD += "RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer\n"
+		environmentInstallCmd += "RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer\n"
 	}
 	if meta["exts"] != "" {
-		installCMD += `ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+		environmentInstallCmd += `ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-`
+RUN docker-php-ext-install ` + meta["exts"] + "\n"
 	}
 
 	// copy source code to /var/www/public, which is Nginx root directory
@@ -67,13 +66,10 @@ RUN echo "` + nginxConf + `" >> /etc/nginx/sites-enabled/default
 `
 	}
 
-	// install dependencies
-	installCmd := "\n"
-	if meta["exts"] != "" {
-		installCmd += `RUN docker-php-ext-install ` + meta["exts"] + "\n"
-	}
+	// install project dependencies
+	projectInstallCmd := "\n"
 	if projectProperty&types.PHPPropertyComposer != 0 {
-		installCmd += `RUN composer install --optimize-autoloader --no-dev` + "\n"
+		projectInstallCmd += `RUN composer install --optimize-autoloader --no-dev` + "\n"
 	}
 
 	startCmd := `
@@ -87,9 +83,9 @@ CMD ["php", "artisan", "octane:start", "--server=swoole", "--host=0.0.0.0", "--p
 	}
 
 	dockerFile := getPhpImage +
-		installCMD +
+		environmentInstallCmd +
 		copyCommand +
-		installCmd +
+		projectInstallCmd +
 		startCmd
 
 	return dockerFile, nil

--- a/internal/php/plan.go
+++ b/internal/php/plan.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
+	"github.com/samber/lo"
 	"github.com/spf13/afero"
 	"github.com/zeabur/zbpack/pkg/types"
 )
@@ -96,14 +98,14 @@ var depMap = map[string][]string{
 	"ext-gmp":     {"libgmp-dev"},
 }
 
-var baseDep = []string{"libicu-dev", "jq", "pkg-config", "unzip", "git"}
+var baseDep = []string{"libicu-dev", "pkg-config", "unzip", "git"}
 
 // DetermineAptDependencies determines the required apt dependencies of the project.
 //
 // We install Nginx server unless server is "swoole".
 func DetermineAptDependencies(source afero.Fs, server string) []string {
 	// deep copy the base dependencies
-	dependencies := append([]string{}, baseDep...)
+	dependencies := slices.Clone(baseDep)
 
 	// If Octane Server is not "swoole", we should install Nginx.
 	//
@@ -130,6 +132,28 @@ func DetermineAptDependencies(source afero.Fs, server string) []string {
 	}
 
 	return dependencies
+}
+
+func DeterminePHPExtensions(source afero.Fs) []string {
+	var extensions []string
+
+	composerJSON, err := parseComposerJSON(source)
+	if err != nil {
+		return extensions
+	}
+
+	if composerJSON.Require == nil {
+		return extensions
+	}
+
+	for dep := range *composerJSON.Require {
+		extName, ok := strings.CutPrefix(dep, "ext-")
+		if ok {
+			extensions = append(extensions, strings.ToLower(extName))
+		}
+	}
+
+	return lo.Uniq(extensions)
 }
 
 // DetermineApplication determines what application the project is using.

--- a/internal/php/plan.go
+++ b/internal/php/plan.go
@@ -134,8 +134,14 @@ func DetermineAptDependencies(source afero.Fs, server string) []string {
 	return dependencies
 }
 
+var baseExt = []string{
+	// php applications often access MySQL databases
+	"pdo", "pdo_mysql", "mysqli",
+}
+
+// DeterminePHPExtensions determines the required PHP extensions from composer.json of the project.
 func DeterminePHPExtensions(source afero.Fs) []string {
-	var extensions []string
+	extensions := slices.Clone(baseExt)
 
 	composerJSON, err := parseComposerJSON(source)
 	if err != nil {

--- a/internal/php/template_test.go
+++ b/internal/php/template_test.go
@@ -35,7 +35,7 @@ func TestTemplate(t *testing.T) {
 	}
 	deps := []string{
 		"nginx",
-		"nginx,owo",
+		"nginx owo",
 	}
 	property := []string{
 		php.PropertyToString(types.PHPPropertyNone),

--- a/internal/php/template_test.go
+++ b/internal/php/template_test.go
@@ -34,8 +34,14 @@ func TestTemplate(t *testing.T) {
 		string(types.PHPFrameworkCodeigniter),
 	}
 	deps := []string{
+		"",
 		"nginx",
 		"nginx owo",
+	}
+	exts := []string{
+		"",
+		"aaa",
+		"aaa bbb",
 	}
 	property := []string{
 		php.PropertyToString(types.PHPPropertyNone),
@@ -55,40 +61,46 @@ func TestTemplate(t *testing.T) {
 				f := f
 				for _, p := range property {
 					p := p
-					t.Run(v+"-"+f+"-"+d+"-"+p, func(t *testing.T) {
-						t.Parallel()
+					for _, e := range exts {
+						e := e
 
-						dockerfile, err := php.GenerateDockerfile(types.PlanMeta{
-							"phpVersion": v,
-							"framework":  f,
-							"deps":       d,
-							"app":        string(types.PHPApplicationDefault),
-							"property":   p,
+						t.Run(v+"-"+f+"-"+d+"-"+p+"-"+e, func(t *testing.T) {
+							t.Parallel()
+
+							dockerfile, err := php.GenerateDockerfile(types.PlanMeta{
+								"phpVersion": v,
+								"framework":  f,
+								"deps":       d,
+								"exts":       e,
+								"app":        string(types.PHPApplicationDefault),
+								"property":   p,
+							})
+
+							assert.NoError(t, err)
+							snaps.MatchSnapshot(t, dockerfile)
 						})
 
-						assert.NoError(t, err)
-						snaps.MatchSnapshot(t, dockerfile)
-					})
+						if f == string(types.PHPFrameworkLaravel) {
+							for _, o := range octaneServer {
+								o := o
 
-					if f == string(types.PHPFrameworkLaravel) {
-						for _, o := range octaneServer {
-							o := o
+								t.Run(v+"-"+f+"-"+d+"-"+p+"-"+e+"+os-"+o, func(t *testing.T) {
+									t.Parallel()
 
-							t.Run(v+"-"+f+"-"+d+"-"+p+"+os-"+o, func(t *testing.T) {
-								t.Parallel()
+									dockerfile, err := php.GenerateDockerfile(types.PlanMeta{
+										"phpVersion":   v,
+										"framework":    f,
+										"deps":         d,
+										"exts":         e,
+										"app":          string(types.PHPApplicationDefault),
+										"property":     p,
+										"octaneServer": o,
+									})
 
-								dockerfile, err := php.GenerateDockerfile(types.PlanMeta{
-									"phpVersion":   v,
-									"framework":    f,
-									"deps":         d,
-									"app":          string(types.PHPApplicationDefault),
-									"property":     p,
-									"octaneServer": o,
+									assert.NoError(t, err)
+									snaps.MatchSnapshot(t, dockerfile)
 								})
-
-								assert.NoError(t, err)
-								snaps.MatchSnapshot(t, dockerfile)
-							})
+							}
 						}
 					}
 				}


### PR DESCRIPTION
#### Description (required)

- Determine the extensions to install in the plan stage and add it to `exts` planMeta.
- Install extensions early (before `COPY`) to leverage caches.
- 'composer.json' is not the "single source of truth" for the extension installation.
- Don't run `apt install` if there is no `aptDeps`.
- Add the `exts` test in snapshot.

#### Related issues & labels (optional)

- Closes ZEA-2569
- Suggested label: `bug` `enhancement`
