### PR TITLE
fix(plan/rust): Fix rust compile binary rename

### DIFF
--- a/internal/rust/template.Dockerfile
+++ b/internal/rust/template.Dockerfile
@@ -42,7 +42,7 @@ RUN if [ ! -x "${EXEFILE}" ]; then \
     echo "${EXEFILE}" > EXEFILE; \
   fi
 
-RUN mv ${EXEFILE} /app/bin/server
+RUN mv $(cat EXEFILE) /app/bin/server
 
 # {{if not (eq .serverless "true")}}
 FROM docker.io/library/debian:bookworm-slim AS runtime

--- a/internal/rust/template.Dockerfile
+++ b/internal/rust/template.Dockerfile
@@ -42,7 +42,7 @@ RUN if [ ! -x "${EXEFILE}" ]; then \
     echo "${EXEFILE}" > EXEFILE; \
   fi
 
-RUN mv $(cat EXEFILE) /app/bin/server
+RUN mv "$(cat EXEFILE)" /app/bin/server
 
 # {{if not (eq .serverless "true")}}
 FROM docker.io/library/debian:bookworm-slim AS runtime


### PR DESCRIPTION
#### Description (required)

This issue fixes binary rename when rust plan compiling.

#### Related issues & labels (optional)

- Closes ZEA-2576
- Suggested label: bug