### PR TITLE
ZEA-2581: install php extensions

### DIFF
--- a/internal/php/__snapshots__/template_test.snap
+++ b/internal/php/__snapshots__/template_test.snap
@@ -19,7 +19,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -37,7 +37,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -73,7 +73,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -93,7 +93,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -129,7 +129,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -148,7 +148,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -186,7 +186,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -207,7 +207,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -243,7 +243,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -262,7 +262,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -300,7 +300,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -321,7 +321,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -398,7 +398,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -416,7 +416,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -434,7 +434,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -453,7 +453,7 @@ RUN docker-php-ext-install pcntl
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -468,7 +468,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -486,7 +486,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -504,7 +504,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -523,7 +523,7 @@ RUN docker-php-ext-install pcntl
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -605,7 +605,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -625,7 +625,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -645,7 +645,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -666,7 +666,7 @@ RUN docker-php-ext-install pcntl
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -683,7 +683,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -703,7 +703,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -723,7 +723,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -744,7 +744,7 @@ RUN docker-php-ext-install pcntl
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -823,7 +823,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -842,7 +842,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -861,7 +861,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -881,7 +881,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -897,7 +897,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -916,7 +916,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -935,7 +935,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -955,7 +955,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1042,7 +1042,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1063,7 +1063,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1084,7 +1084,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1106,7 +1106,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1124,7 +1124,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1145,7 +1145,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1166,7 +1166,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1188,7 +1188,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1267,7 +1267,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1286,7 +1286,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1305,7 +1305,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1325,7 +1325,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1341,7 +1341,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1360,7 +1360,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1379,7 +1379,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1399,7 +1399,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1486,7 +1486,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1507,7 +1507,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1528,7 +1528,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1550,7 +1550,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1568,7 +1568,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1589,7 +1589,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1610,7 +1610,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1632,7 +1632,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -1663,7 +1663,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1681,7 +1681,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1717,7 +1717,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1737,7 +1737,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1773,7 +1773,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1792,7 +1792,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1830,7 +1830,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1851,7 +1851,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1887,7 +1887,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1906,7 +1906,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1944,7 +1944,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1965,7 +1965,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -1999,7 +1999,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2017,7 +2017,7 @@ FROM docker.io/library/php:7-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2053,7 +2053,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2073,7 +2073,7 @@ FROM docker.io/library/php:7-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2109,7 +2109,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2128,7 +2128,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2166,7 +2166,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2187,7 +2187,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2223,7 +2223,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2242,7 +2242,7 @@ FROM docker.io/library/php:7-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2280,7 +2280,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2301,7 +2301,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2335,7 +2335,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2353,7 +2353,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2389,7 +2389,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2409,7 +2409,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2445,7 +2445,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2464,7 +2464,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2502,7 +2502,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2523,7 +2523,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2559,7 +2559,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2578,7 +2578,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2616,7 +2616,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2637,7 +2637,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2714,7 +2714,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2732,7 +2732,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2750,7 +2750,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2769,7 +2769,7 @@ RUN docker-php-ext-install pcntl
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2784,7 +2784,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2802,7 +2802,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2820,7 +2820,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2839,7 +2839,7 @@ RUN docker-php-ext-install pcntl
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2921,7 +2921,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2941,7 +2941,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2961,7 +2961,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2982,7 +2982,7 @@ RUN docker-php-ext-install pcntl
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -2999,7 +2999,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3019,7 +3019,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3039,7 +3039,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3060,7 +3060,7 @@ RUN docker-php-ext-install pcntl
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3139,7 +3139,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3158,7 +3158,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3177,7 +3177,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3197,7 +3197,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3213,7 +3213,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3232,7 +3232,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3251,7 +3251,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3271,7 +3271,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3358,7 +3358,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3379,7 +3379,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3400,7 +3400,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3422,7 +3422,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3440,7 +3440,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3461,7 +3461,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3482,7 +3482,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3504,7 +3504,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3583,7 +3583,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3602,7 +3602,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3621,7 +3621,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3641,7 +3641,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3657,7 +3657,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3676,7 +3676,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3695,7 +3695,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3715,7 +3715,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3802,7 +3802,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3823,7 +3823,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3844,7 +3844,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3866,7 +3866,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3884,7 +3884,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3905,7 +3905,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3926,7 +3926,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3948,7 +3948,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -3979,7 +3979,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -3997,7 +3997,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4033,7 +4033,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4053,7 +4053,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4089,7 +4089,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4108,7 +4108,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4146,7 +4146,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4167,7 +4167,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4203,7 +4203,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4222,7 +4222,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4260,7 +4260,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4281,7 +4281,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -4315,7 +4315,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4333,7 +4333,7 @@ FROM docker.io/library/php:8.1-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4369,7 +4369,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4389,7 +4389,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4425,7 +4425,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4444,7 +4444,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4482,7 +4482,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4503,7 +4503,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4539,7 +4539,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4558,7 +4558,7 @@ FROM docker.io/library/php:8.1-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4596,7 +4596,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4617,7 +4617,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4651,7 +4651,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4669,7 +4669,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4705,7 +4705,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4725,7 +4725,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4761,7 +4761,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4780,7 +4780,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4818,7 +4818,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4839,7 +4839,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4875,7 +4875,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4894,7 +4894,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4932,7 +4932,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -4953,7 +4953,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5030,7 +5030,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5048,7 +5048,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5066,7 +5066,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5085,7 +5085,7 @@ RUN docker-php-ext-install pcntl
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5100,7 +5100,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5118,7 +5118,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5136,7 +5136,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5155,7 +5155,7 @@ RUN docker-php-ext-install pcntl
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5237,7 +5237,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5257,7 +5257,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5277,7 +5277,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5298,7 +5298,7 @@ RUN docker-php-ext-install pcntl
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5315,7 +5315,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5335,7 +5335,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5355,7 +5355,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5376,7 +5376,7 @@ RUN docker-php-ext-install pcntl
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5455,7 +5455,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5474,7 +5474,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5493,7 +5493,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5513,7 +5513,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5529,7 +5529,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5548,7 +5548,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5567,7 +5567,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5587,7 +5587,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5674,7 +5674,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5695,7 +5695,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5716,7 +5716,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5738,7 +5738,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5756,7 +5756,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5777,7 +5777,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5798,7 +5798,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5820,7 +5820,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5899,7 +5899,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5918,7 +5918,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5937,7 +5937,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5957,7 +5957,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5973,7 +5973,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -5992,7 +5992,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6011,7 +6011,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6031,7 +6031,7 @@ RUN docker-php-ext-install pcntl
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6118,7 +6118,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6139,7 +6139,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6160,7 +6160,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6182,7 +6182,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6200,7 +6200,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6221,7 +6221,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6242,7 +6242,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6264,7 +6264,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6295,7 +6295,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6313,7 +6313,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6349,7 +6349,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6369,7 +6369,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6405,7 +6405,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6424,7 +6424,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6462,7 +6462,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6483,7 +6483,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6519,7 +6519,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6538,7 +6538,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6576,7 +6576,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6597,7 +6597,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www/public
 WORKDIR /var/www/public
@@ -6631,7 +6631,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6649,7 +6649,7 @@ FROM docker.io/library/php:8.2-fpm
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6685,7 +6685,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6705,7 +6705,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6741,7 +6741,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6760,7 +6760,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6798,7 +6798,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6819,7 +6819,7 @@ RUN apt-get update && apt-get install -y nginx && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6855,7 +6855,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6874,7 +6874,7 @@ FROM docker.io/library/php:8.2-fpm
 RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6912,7 +6912,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa
+RUN install-php-extensions aaa
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www
@@ -6933,7 +6933,7 @@ RUN apt-get update && apt-get install -y nginx owo && rm -rf /var/lib/apt/lists/
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install aaa bbb
+RUN install-php-extensions aaa bbb
 
 COPY --chown=www-data:www-data . /var/www
 WORKDIR /var/www

--- a/internal/php/php.go
+++ b/internal/php/php.go
@@ -37,7 +37,7 @@ func GenerateDockerfile(meta types.PlanMeta) (string, error) {
 	if meta["exts"] != "" {
 		environmentInstallCmd += `ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 RUN chmod +x /usr/local/bin/install-php-extensions && sync
-RUN docker-php-ext-install ` + meta["exts"] + "\n"
+RUN install-php-extensions ` + meta["exts"] + "\n"
 	}
 
 	// copy source code to /var/www/public, which is Nginx root directory


### PR DESCRIPTION

#### Description (required)

Use `install-php-extensions` to install extensions to simplify the installation of dependencies.

#### Related issues & labels (optional)

- Closes ZEA-2581
- Suggested label: `enhancement` (or `bug)
