### PR TITLE
fix(planner/python): Matched ) is not required

### DIFF
--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -252,7 +252,7 @@ func DetermineWsgi(ctx *pythonPlanContext) string {
 		if constructor != "" {
 			entryFile := DetermineEntry(ctx)
 
-			re := regexp.MustCompile(`(\w+)\s*=\s*` + constructor + `\([^)]*\)`)
+			re := regexp.MustCompile(`(\w+)\s*=\s*` + constructor + `\(`)
 			content, err := afero.ReadFile(src, entryFile)
 			if err != nil {
 				return ""


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

It is for fixing such cases:

    FastAPI(   # no trailing ')'
        name="app"
    )
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-2586<!-- Add an issue number if this PR will close it. -->
- Suggested label: bug<!-- Help us triage by suggesting one of our labels that describes your PR -->
