### PR TITLE
feat: Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 1. Fork the repository and clone it to your local machine.
 2. Make sure you have Go installed on your machine. You can download it from the official website: <https://golang.org/dl/>
 3. Navigate to the root of the project and run `go mod download` to download the necessary dependencies.
+4. Make sure [buildctl](https://github.com/moby/buildkit) is installed and buildkitd is running.
 
 ### `zbpack`
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

When I try to use zbpack, when executing the `./zbpack [the directory to analyze and build]` command, I am prompted that "buildctl is not installed or buildkitd is not running". Therefore, I suggest that you consider adding instructions for this section to the readme, which facilitate better use by developers like me who are trying to use it for the first time. Thanks for your time.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label:  Readme  Description 
