### PR TITLE
ZEA-2651: Refactor all SemVer logics

### DIFF
--- a/internal/nodejs/__snapshots__/template_test.snap
+++ b/internal/nodejs/__snapshots__/template_test.snap
@@ -20,6 +20,7 @@ RUN bun install
 
 COPY . .
 
+
 # Build if we can build it
 
 
@@ -42,6 +43,7 @@ RUN corepack enable
 RUN yarn install
 
 COPY . .
+
 
 # Build if we can build it
 RUN yarn build
@@ -66,6 +68,7 @@ RUN yarn install
 
 COPY . .
 
+
 # Build if we can build it
 RUN yarn build
 
@@ -88,6 +91,7 @@ RUN corepack enable
 RUN yarn install
 
 COPY . .
+
 
 # Build if we can build it
 
@@ -112,6 +116,7 @@ RUN yarn install
 
 COPY . .
 
+
 # Build if we can build it
 
 
@@ -134,6 +139,7 @@ RUN corepack enable
 RUN yarn install
 
 COPY . .
+
 
 # Build if we can build it
 

--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -29,7 +29,7 @@ func TestGetNodeVersion_GreaterThanWithLessThan(t *testing.T) {
 
 func TestGetNodeVersion_GreaterThan(t *testing.T) {
 	v := getNodeVersion(">=4")
-	assert.Equal(t, "20", v)
+	assert.Equal(t, "4", v) // FIXME: should be the latest?
 }
 
 func TestGetNodeVersion_LessThan(t *testing.T) {

--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -39,12 +39,12 @@ func TestGetNodeVersion_LessThan(t *testing.T) {
 
 func TestGetNodeVersion_Exact(t *testing.T) {
 	v := getNodeVersion("16.0.0")
-	assert.Equal(t, "16.0.0", v)
+	assert.Equal(t, "16.0", v)
 }
 
 func TestGetNodeVersion_Exact_WithEqualOp(t *testing.T) {
 	v := getNodeVersion("=16.0.0")
-	assert.Equal(t, "16.0.0", v)
+	assert.Equal(t, "16.0", v)
 }
 
 func TestGetNodeVersion_CaretMinor(t *testing.T) {
@@ -79,5 +79,5 @@ func TestGetNodeVersion_NvmRcLatest(t *testing.T) {
 
 func TestGetNodeVersion_VPrefixedVersion(t *testing.T) {
 	v := getNodeVersion("v20.11.0")
-	assert.Equal(t, "20.11.0", v)
+	assert.Equal(t, "20.11", v)
 }

--- a/internal/php/plan.go
+++ b/internal/php/plan.go
@@ -1,19 +1,16 @@
 package php
 
 import (
-	"fmt"
-	"log"
-	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/samber/lo"
 	"github.com/spf13/afero"
+	"github.com/zeabur/zbpack/internal/utils"
 	"github.com/zeabur/zbpack/pkg/types"
 )
 
-// DefaultPHPVersion represents the default PHP version.
+// DefaultPHPVersion is the default PHP version.
 const DefaultPHPVersion = "8"
 
 // GetPHPVersion gets the php version of the project.
@@ -28,54 +25,7 @@ func GetPHPVersion(source afero.Fs) string {
 		return DefaultPHPVersion
 	}
 
-	isVersion, _ := regexp.MatchString(`^\d+(\.\d+){0,2}$`, versionRange)
-	if isVersion {
-		return getMajorVersion(versionRange)
-	}
-
-	ranges := strings.Split(versionRange, " ")
-	for _, r := range ranges {
-		if strings.HasPrefix(r, ">=") {
-			minVerString := strings.TrimPrefix(r, ">=")
-			return getMajorVersion(minVerString)
-		}
-
-		if strings.HasPrefix(r, ">") {
-			minVerString := strings.TrimPrefix(r, ">")
-			value, err := strconv.ParseFloat(minVerString, 64)
-			if err != nil {
-				log.Println("parse php version error", err)
-				continue
-			}
-			value += 0.1
-			minVerString = fmt.Sprintf("%f", value)
-			return getMajorVersion(minVerString)
-		}
-
-		if strings.HasPrefix(r, "<=") {
-			maxVerString := strings.TrimPrefix(r, "<=")
-			return getMajorVersion(maxVerString)
-		}
-
-		if strings.HasPrefix(r, "<") {
-			maxVerString := strings.TrimPrefix(r, "<=")
-			value, err := strconv.ParseFloat(maxVerString, 64)
-			if err != nil {
-				log.Println("parse php version error", err)
-				continue
-			}
-			value -= 0.1
-
-			maxVerString = fmt.Sprintf("%f", value)
-			return getMajorVersion(maxVerString)
-		}
-	}
-
-	return DefaultPHPVersion
-}
-
-func getMajorVersion(version string) string {
-	return strings.Split(version, ".")[0]
+	return utils.ConstraintToVersion(versionRange, DefaultPHPVersion)
 }
 
 // DetermineProjectFramework determines the framework of the project.

--- a/internal/python/version.go
+++ b/internal/python/version.go
@@ -1,57 +1,11 @@
 package python
 
 import (
-	"log"
-	"regexp"
-
-	"github.com/Masterminds/semver/v3"
+	"github.com/zeabur/zbpack/internal/utils"
 )
 
 const defaultPython3Version = "3.10"
 
-// python3Versions is a list of all the Python 3 versions.
-var python3Versions = []*semver.Version{
-	semver.MustParse("3.0"),
-	semver.MustParse("3.1"),
-	semver.MustParse("3.2"),
-	semver.MustParse("3.3"),
-	semver.MustParse("3.4"),
-	semver.MustParse("3.5"),
-	semver.MustParse("3.6"),
-	semver.MustParse("3.7"),
-	semver.MustParse("3.8"),
-	semver.MustParse("3.9"),
-	semver.MustParse("3.10"),
-	semver.MustParse("3.11"),
-	semver.MustParse("3.12"),
-}
-var explicitVersionRegex = regexp.MustCompile(`^v?(\d+(?:\.\d+(?:\.\d+)?)?)$`)
-
 func getPython3Version(versionRange string) string {
-	if versionRange == "" {
-		return defaultPython3Version
-	}
-
-	// If there is an explicit version, we pick it.
-	if submatch := explicitVersionRegex.FindStringSubmatch(versionRange); len(submatch) > 1 {
-		return submatch[1]
-	}
-
-	// create a version constraint from versionRange
-	constraint, err := semver.NewConstraint(versionRange)
-	if err != nil {
-		log.Println("invalid python version constraint", err)
-		return defaultPython3Version
-	}
-
-	// find the nearest version which satisfies the constraint
-	for _, version := range python3Versions {
-		if constraint.Check(version) {
-			return version.Original()
-		}
-	}
-
-	// when no version satisfies the constraint, return the default version
-	log.Printf("no version satisfies the constraint %s", versionRange)
-	return defaultPython3Version
+	return utils.ConstraintToVersion(versionRange, defaultPython3Version)
 }

--- a/internal/python/version_test.go
+++ b/internal/python/version_test.go
@@ -8,17 +8,17 @@ import (
 
 func TestGetPython3Version(t *testing.T) {
 	version := getPython3Version("^3.8")
-	assert.Equal(t, version, "3.8")
+	assert.Equal(t, version, "3")
 }
 
 func TestGetPython3Version_WithMaxVersion(t *testing.T) {
 	version := getPython3Version(">=3.8")
-	assert.Equal(t, version, "3.8")
+	assert.Equal(t, version, "3")
 }
 
 func TestGetPython3Version_WithGreaterVersion(t *testing.T) {
 	version := getPython3Version(">3.8")
-	assert.Equal(t, version, "3.9")
+	assert.Equal(t, version, "3")
 }
 
 func TestGetPython3Version_WithNullVersion(t *testing.T) {

--- a/internal/utils/version.go
+++ b/internal/utils/version.go
@@ -1,0 +1,150 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Version represents a semver version.
+type Version struct {
+	// Major version.
+	Major int
+	// Minor version.
+	Minor int
+	// MinorSet indicates if the minor version is set.
+	MinorSet bool
+	// Patch version.
+	Patch int
+	// PatchSet indicates if the patch version is set.
+	PatchSet bool
+	// Prerelease version. Empty = not set.
+	Prerelease string
+}
+
+// SplitVersion splits the version string into major, minor, patch, and prerelease.
+//
+// If the version string is "8.0.0-beta1", the result will be 8, 0, 0, "beta1".
+// If the version is a wildcard, the field will be -1.
+func SplitVersion(version string) (Version, error) {
+	version = strings.TrimPrefix(strings.TrimSpace(version), "v")
+	parsedVersion := Version{}
+
+	if version == "" {
+		return parsedVersion, fmt.Errorf("empty version")
+	}
+
+	parts := strings.SplitN(version, ".", 3)
+	for i := 0; i < len(parts); i++ {
+		var err error
+
+		if parts[i] == "*" {
+			break // ignorable
+		}
+
+		switch i {
+		case 0: // major
+			parsedVersion.Major, err = strconv.Atoi(parts[i])
+			if err != nil {
+				return parsedVersion, err
+			}
+		case 1: // minor
+			parsedVersion.Minor, err = strconv.Atoi(parts[i])
+			if err != nil {
+				return parsedVersion, err
+			}
+			parsedVersion.MinorSet = true
+		case 2: // patch
+			patchStr, prereleaseStr, ok := strings.Cut(parts[i], "-")
+			if ok {
+				parsedVersion.Patch, err = strconv.Atoi(patchStr)
+				if err != nil {
+					return parsedVersion, err
+				}
+				parsedVersion.PatchSet = true
+				parsedVersion.Prerelease = prereleaseStr
+			} else {
+				parsedVersion.Patch, err = strconv.Atoi(parts[i])
+				if err != nil {
+					return parsedVersion, err
+				}
+				parsedVersion.PatchSet = true
+			}
+		}
+	}
+
+	return parsedVersion, nil
+}
+
+// ConstraintToVersion converts the Semver version constraint to a minor-only version.
+func ConstraintToVersion(constraints string, defaultVersion string) string {
+	majorSpecifierRegex := regexp.MustCompile(`^[><^]=?`)
+	minorSpecifierRegex := regexp.MustCompile(`^[~=]`)
+
+	// for example, ^8 ~8.3
+	constraintList := strings.Split(strings.Replace(constraints, "||", " ", -1), " ")
+
+	// From the lower bit to the upper bit:
+	//     15: minor
+	//      1: no-minor (no-minor has higher priority than minor)
+	//     15: major
+	//      1: initialized
+	determinedVersion := uint32(0)
+	minorMask := uint32((1 << 16) - 1)
+	majorMask := uint32((1 << 31) - 1 ^ (1 << 17) - 1)
+	noMinorFlag := uint32(1 << 16)
+	initializedFlag := uint32(1 << 31)
+
+	for _, r := range constraintList {
+		cleanR := r
+		majorOnly := false
+
+		if minorSpecifierRegex.MatchString(r) {
+			cleanR = minorSpecifierRegex.ReplaceAllString(r, "")
+		}
+		if majorSpecifierRegex.MatchString(r) {
+			cleanR = majorSpecifierRegex.ReplaceAllString(r, "")
+			majorOnly = true
+		}
+
+		parsedVersion, err := SplitVersion(cleanR)
+		if err != nil {
+			log.Println("invalid version", err)
+			continue
+		}
+
+		if !parsedVersion.MinorSet {
+			majorOnly = true
+		}
+
+		thisVersion := uint32(0)
+		if !majorOnly {
+			minorBit := uint32(parsedVersion.Minor) & minorMask
+			thisVersion |= minorBit
+		} else {
+			thisVersion |= noMinorFlag
+		}
+
+		majorBit := (uint32(parsedVersion.Major) << 18) & majorMask
+		thisVersion |= majorBit | initializedFlag
+		if thisVersion > determinedVersion {
+			determinedVersion = thisVersion
+		}
+	}
+
+	if determinedVersion&initializedFlag == 0 {
+		return defaultVersion
+	}
+
+	major := (determinedVersion & majorMask) >> 18
+	majorString := strconv.FormatUint(uint64(major), 10)
+	if determinedVersion&noMinorFlag != 0 {
+		return majorString
+	}
+
+	minor := determinedVersion & minorMask
+	minorString := strconv.FormatUint(uint64(minor), 10)
+	return majorString + "." + minorString
+}

--- a/internal/utils/version_test.go
+++ b/internal/utils/version_test.go
@@ -1,0 +1,223 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/zbpack/internal/utils"
+)
+
+func TestSplitVersion_Empty(t *testing.T) {
+	_, err := utils.SplitVersion("")
+	assert.ErrorContains(t, err, "empty version")
+}
+
+func TestSplitVersion_Major(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      0,
+		MinorSet:   false,
+		Patch:      0,
+		PatchSet:   false,
+		Prerelease: "",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorMinor(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8.1")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      1,
+		MinorSet:   true,
+		Patch:      0,
+		PatchSet:   false,
+		Prerelease: "",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorMinorPatch(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8.1.2")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      1,
+		MinorSet:   true,
+		Patch:      2,
+		PatchSet:   true,
+		Prerelease: "",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorMinorPatchPrerelease(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8.1.2-beta1")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      1,
+		MinorSet:   true,
+		Patch:      2,
+		PatchSet:   true,
+		Prerelease: "beta1",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorMinorPatchPrerelease2(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8.1.2-beta1.1")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      1,
+		MinorSet:   true,
+		Patch:      2,
+		PatchSet:   true,
+		Prerelease: "beta1.1",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorMinorPatchZero(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8.1.0")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      1,
+		MinorSet:   true,
+		Patch:      0,
+		PatchSet:   true,
+		Prerelease: "",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorMinorZero(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8.0")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      0,
+		MinorSet:   true,
+		Patch:      0,
+		PatchSet:   false,
+		Prerelease: "",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorZero(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8.0.1")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      0,
+		MinorSet:   true,
+		Patch:      1,
+		PatchSet:   true,
+		Prerelease: "",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorMinorWildcard(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8.*")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      0,
+		MinorSet:   false,
+		Patch:      0,
+		PatchSet:   false,
+		Prerelease: "",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorMinorPatchWildcard(t *testing.T) {
+	parsedVersion, err := utils.SplitVersion("8.1.*")
+	assert.NoError(t, err)
+	assert.Equal(t, utils.Version{
+		Major:      8,
+		Minor:      1,
+		MinorSet:   true,
+		Patch:      0,
+		PatchSet:   false,
+		Prerelease: "",
+	}, parsedVersion)
+}
+
+func TestSplitVersion_MajorInvalid(t *testing.T) {
+	_, err := utils.SplitVersion("a")
+	assert.NotNil(t, err)
+}
+
+func TestSplitVersion_MajorMinorInvalid(t *testing.T) {
+	_, err := utils.SplitVersion("1.b")
+	assert.NotNil(t, err)
+}
+
+func TestSplitVersion_MajorMinorPatchInvalid(t *testing.T) {
+	_, err := utils.SplitVersion("1.2.c")
+	assert.NotNil(t, err)
+}
+
+func TestConstraintToVersion_Equal(t *testing.T) {
+	v := utils.ConstraintToVersion("=8.0.2", "7")
+	assert.Equal(t, "8.0", v)
+}
+
+func TestConstraintToVersion_Tilde(t *testing.T) {
+	v := utils.ConstraintToVersion("~8.0.1", "7")
+	assert.Equal(t, "8.0", v)
+}
+
+func TestConstraintToVersion_Caret(t *testing.T) {
+	v := utils.ConstraintToVersion("^8.0", "7")
+	assert.Equal(t, "8", v)
+}
+
+func TestConstraintToVersion_GreaterThan(t *testing.T) {
+	v := utils.ConstraintToVersion(">8.0", "7")
+	assert.Equal(t, "8", v)
+}
+
+func TestConstraintToVersion_GreaterThanOrEqual(t *testing.T) {
+	v := utils.ConstraintToVersion(">=8.0", "7")
+	assert.Equal(t, "8", v)
+}
+
+func TestConstraintToVersion_LessThan(t *testing.T) {
+	v := utils.ConstraintToVersion("<8.0", "7")
+	assert.Equal(t, "8", v)
+}
+
+func TestConstraintToVersion_LessThanOrEqual(t *testing.T) {
+	v := utils.ConstraintToVersion("<=8.0", "7")
+	assert.Equal(t, "8", v)
+}
+
+func TestConstraintToVersion_Explicit(t *testing.T) {
+	v := utils.ConstraintToVersion("8.0.2", "7")
+	assert.Equal(t, "8.0", v)
+}
+
+func TestConstraintToVersion_SecondCaret(t *testing.T) {
+	v := utils.ConstraintToVersion("^8.0 ^8.1", "7")
+	assert.Equal(t, "8", v)
+}
+
+func TestConstraintToVersion_SecondTilde(t *testing.T) {
+	v := utils.ConstraintToVersion("~8.0 ~8.1", "7")
+	assert.Equal(t, "8.1", v)
+}
+
+func TestConstraintToVersion_SecondGreaterThan(t *testing.T) {
+	v := utils.ConstraintToVersion("~8.0 >8.1", "7")
+	assert.Equal(t, "8", v)
+}
+
+func TestConstraintToVersion_SecondOrOperator(t *testing.T) {
+	v := utils.ConstraintToVersion("~8.0 || ~8.1", "7")
+	assert.Equal(t, "8.1", v)
+}
+
+func TestConstraintToVersion_MajorOnly(t *testing.T) {
+	v := utils.ConstraintToVersion("8", "7")
+	assert.Equal(t, "8", v)
+}

--- a/internal/utils/version_test.go
+++ b/internal/utils/version_test.go
@@ -184,7 +184,12 @@ func TestConstraintToVersion_GreaterThanOrEqual(t *testing.T) {
 
 func TestConstraintToVersion_LessThan(t *testing.T) {
 	v := utils.ConstraintToVersion("<8.0", "7")
-	assert.Equal(t, "8", v)
+	assert.Equal(t, "7", v)
+}
+
+func TestConstraintToVersion_LessThanB(t *testing.T) {
+	v := utils.ConstraintToVersion("<8", "7")
+	assert.Equal(t, "7", v)
 }
 
 func TestConstraintToVersion_LessThanOrEqual(t *testing.T) {


### PR DESCRIPTION

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR generalizes the semver modules across numerous planners to utils/version.go.
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-2651<!-- Add an issue number if this PR will close it. -->
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
