### PR TITLE
fix(planner/nodejs): Disable cache if monorepo detected

### DIFF
--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -420,6 +420,7 @@ func GetEntry(ctx *nodePlanContext) string {
 // GetInstallCmd gets the installation command of the Node.js project.
 func GetInstallCmd(ctx *nodePlanContext) string {
 	cmd := &ctx.InstallCmd
+	src := ctx.Src
 
 	if installCmd, err := cmd.Take(); err == nil {
 		return installCmd
@@ -427,6 +428,12 @@ func GetInstallCmd(ctx *nodePlanContext) string {
 
 	pkgManager := DeterminePackageManager(ctx)
 	shouldCacheDependencies := plan.Cast(ctx.Config.Get(ConfigCacheDependencies), cast.ToBoolE).TakeOr(true)
+
+	// monorepo
+	if shouldCacheDependencies && utils.HasFile(src, "pnpm-workspace.yaml", "pnpm-workspace.yml", "packages") {
+		log.Println("Detected Monorepo. Disabling dependency caching.")
+		shouldCacheDependencies = false
+	}
 
 	var cmds []string
 	if shouldCacheDependencies {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Disable the dependency copying stage if the monorepo (`pnpm-workspace`, `packages` folder) is detected.
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-2700<!-- Add an issue number if this PR will close it. -->
- Suggested label: bug<!-- Help us triage by suggesting one of our labels that describes your PR -->
