### PR TITLE
fix(planner/nodejs): Remove embed

### DIFF
--- a/internal/nodejs/remix/main.go
+++ b/internal/nodejs/remix/main.go
@@ -2,7 +2,6 @@
 package remix
 
 import (
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"log"


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

The //go:embed instruction has been removed in f7776feaf916a113fb2130cbde980eefcc561cea

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Fix CI https://github.com/zeabur/zbpack/actions/runs/8818109338/job/24206135890
- Suggested label: improvement<!-- Help us triage by suggesting one of our labels that describes your PR -->
