### PR TITLE
Fix CI and panics

### DIFF
--- a/internal/dotnet/dotnet.go
+++ b/internal/dotnet/dotnet.go
@@ -13,9 +13,10 @@ import (
 
 // TemplateContext is the context for the Dotnet Dockerfile template.
 type TemplateContext struct {
-	DotnetVer string
-	Out       string
-	Static    bool
+	DotnetVer    string
+	Out          string
+	Static       bool
+	SubmoduleDir string
 }
 
 //go:embed templates
@@ -37,8 +38,9 @@ func (c TemplateContext) Execute() (string, error) {
 // GenerateDockerfile generates the Dockerfile for Dotnet projects.
 func GenerateDockerfile(meta types.PlanMeta) (string, error) {
 	context := TemplateContext{
-		DotnetVer: meta["sdk"],
-		Out:       strings.TrimSuffix(meta["entryPoint"], ".csproj"),
+		DotnetVer:    meta["sdk"],
+		Out:          strings.TrimSuffix(meta["entryPoint"], ".csproj"),
+		SubmoduleDir: meta["submoduleDir"],
 	}
 
 	if framework := meta["framework"]; framework == "blazorwasm" {

--- a/internal/dotnet/identify.go
+++ b/internal/dotnet/identify.go
@@ -48,17 +48,17 @@ func (i *identify) findEntryPoint(fs afero.Fs) (string, error) {
 func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
 	entryPoint, err := i.findEntryPoint(options.Source)
 	if err != nil {
-		panic(err)
+		return plan.Continue()
 	}
 
 	sdkVer, err := DetermineSDKVersion(entryPoint, options.Source)
 	if err != nil {
-		panic(err)
+		return plan.Continue()
 	}
 
 	framework, err := DetermineFramework(entryPoint, options.Source)
 	if err != nil {
-		panic(err)
+		return plan.Continue()
 	}
 
 	return types.PlanMeta{

--- a/internal/dotnet/identify.go
+++ b/internal/dotnet/identify.go
@@ -26,7 +26,11 @@ func (i *identify) Match(fs afero.Fs) bool {
 	return utils.HasFile(fs, "Program.cs", "Startup.cs")
 }
 
-func (i *identify) findEntryPoint(fs afero.Fs) (string, error) {
+func (i *identify) findEntryPoint(fs afero.Fs, currentSubmoduleName string) (string, error) {
+	if exist, _ := afero.Exists(fs, currentSubmoduleName+".csproj"); exist {
+		return currentSubmoduleName + ".csproj", nil
+	}
+
 	files, err := afero.ReadDir(fs, ".")
 	if err != nil {
 		return "", err
@@ -46,7 +50,7 @@ func (i *identify) findEntryPoint(fs afero.Fs) (string, error) {
 }
 
 func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
-	entryPoint, err := i.findEntryPoint(options.Source)
+	entryPoint, err := i.findEntryPoint(options.Source, options.SubmoduleName)
 	if err != nil {
 		return plan.Continue()
 	}

--- a/internal/dotnet/identify.go
+++ b/internal/dotnet/identify.go
@@ -2,9 +2,13 @@ package dotnet
 
 import (
 	"errors"
+	"log"
+	"os"
 	"strings"
 
+	"github.com/samber/lo"
 	"github.com/spf13/afero"
+	"github.com/spf13/cast"
 
 	"github.com/zeabur/zbpack/internal/utils"
 	"github.com/zeabur/zbpack/pkg/plan"
@@ -23,17 +27,43 @@ func (i *identify) PlanType() types.PlanType {
 }
 
 func (i *identify) Match(fs afero.Fs) bool {
-	return utils.HasFile(fs, "Program.cs", "Startup.cs")
-}
-
-func (i *identify) findEntryPoint(fs afero.Fs, currentSubmoduleName string) (string, error) {
-	if exist, _ := afero.Exists(fs, currentSubmoduleName+".csproj"); exist {
-		return currentSubmoduleName + ".csproj", nil
+	if utils.HasFile(fs, "Program.cs", "Startup.cs") {
+		return true
 	}
 
-	files, err := afero.ReadDir(fs, ".")
+	fi, err := afero.ReadDir(fs, ".")
+	if err == nil {
+		return lo.ContainsBy(fi, func(f os.FileInfo) bool {
+			return !f.IsDir() &&
+				(strings.HasSuffix(f.Name(), ".sln") ||
+					strings.HasSuffix(f.Name(), ".csproj"))
+		})
+	}
+
+	return false
+}
+
+func (i *identify) findEntryPoint(
+	fs afero.Fs,
+	config plan.ImmutableProjectConfiguration,
+	currentSubmoduleName string,
+) (submoduleDir string, file string, err error) {
+	moduleFs := fs
+
+	if configSubmoduleDir, err := plan.Cast(
+		config.Get("dotnet.submoduleDir"), cast.ToStringE,
+	).Take(); err == nil && configSubmoduleDir != "" {
+		submoduleDir = configSubmoduleDir
+		moduleFs = afero.NewBasePathFs(fs, configSubmoduleDir)
+	}
+
+	if exist, _ := afero.Exists(moduleFs, currentSubmoduleName+".csproj"); exist {
+		return submoduleDir, currentSubmoduleName + ".csproj", nil
+	}
+
+	files, err := afero.ReadDir(moduleFs, ".")
 	if err != nil {
-		return "", err
+		return submoduleDir, "", err
 	}
 
 	for _, file := range files {
@@ -42,33 +72,42 @@ func (i *identify) findEntryPoint(fs afero.Fs, currentSubmoduleName string) (str
 		}
 
 		if strings.HasSuffix(file.Name(), ".csproj") {
-			return file.Name(), nil
+			return submoduleDir, file.Name(), nil
 		}
 	}
 
-	return "", errors.New("no .csproj file found")
+	return "", "", errors.New("no .csproj file found")
 }
 
 func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
-	entryPoint, err := i.findEntryPoint(options.Source, options.SubmoduleName)
+	submoduleDir, entryPoint, err := i.findEntryPoint(options.Source, options.Config, options.SubmoduleName)
 	if err != nil {
+		log.Printf("failed to find entrypoint: %s", err)
 		return plan.Continue()
 	}
 
-	sdkVer, err := DetermineSDKVersion(entryPoint, options.Source)
+	moduleFs := options.Source
+	if submoduleDir != "" {
+		moduleFs = afero.NewBasePathFs(options.Source, submoduleDir)
+	}
+
+	sdkVer, err := DetermineSDKVersion(entryPoint, moduleFs)
 	if err != nil {
+		log.Printf("failed to get sdk version: %s", err)
 		return plan.Continue()
 	}
 
-	framework, err := DetermineFramework(entryPoint, options.Source)
+	framework, err := DetermineFramework(entryPoint, moduleFs)
 	if err != nil {
+		log.Printf("failed to get framework: %s", err)
 		return plan.Continue()
 	}
 
 	return types.PlanMeta{
-		"sdk":        sdkVer,
-		"entryPoint": entryPoint,
-		"framework":  framework,
+		"sdk":          sdkVer,
+		"entryPoint":   entryPoint,
+		"submoduleDir": submoduleDir,
+		"framework":    framework,
 	}
 }
 

--- a/internal/dotnet/identify_test.go
+++ b/internal/dotnet/identify_test.go
@@ -64,6 +64,6 @@ func TestPlanMeta_Found(t *testing.T) {
 	planMeta := identifier.PlanMeta(options)
 
 	assert.NotEmpty(t, planMeta)
-	assert.Equal(t, planMeta["sdk"], "7.0")
-	assert.Equal(t, planMeta["entryPoint"], "dotnetapp")
+	assert.Equal(t, "7.0", planMeta["sdk"])
+	assert.Equal(t, "dotnetapp", planMeta["entryPoint"])
 }

--- a/internal/dotnet/identify_test.go
+++ b/internal/dotnet/identify_test.go
@@ -65,5 +65,5 @@ func TestPlanMeta_Found(t *testing.T) {
 
 	assert.NotEmpty(t, planMeta)
 	assert.Equal(t, "7.0", planMeta["sdk"])
-	assert.Equal(t, "dotnetapp", planMeta["entryPoint"])
+	assert.Equal(t, "dotnetapp.csproj", planMeta["entryPoint"])
 }

--- a/internal/dotnet/plan_test.go
+++ b/internal/dotnet/plan_test.go
@@ -23,7 +23,7 @@ func TestDetermineSDKVersion_Valid(t *testing.T) {
 
 	ver, err := DetermineSDKVersion("dotnetapp", fs)
 	assert.NoError(t, err)
-	assert.Equal(t, ver, "7.0")
+	assert.Equal(t, "7.0", ver)
 }
 
 func TestDetermineFramework_EmptyEntryPoint(t *testing.T) {
@@ -42,5 +42,5 @@ func TestDetermineFramework_Valid(t *testing.T) {
 
 	framework, err := DetermineFramework("dotnetapp", fs)
 	assert.NoError(t, err)
-	assert.Equal(t, framework, "console")
+	assert.Equal(t, "console", framework)
 }

--- a/internal/dotnet/plan_test.go
+++ b/internal/dotnet/plan_test.go
@@ -21,7 +21,7 @@ func TestDetermineSDKVersion_Valid(t *testing.T) {
 
 	fs := afero.NewBasePathFs(afero.NewOsFs(), path)
 
-	ver, err := DetermineSDKVersion("dotnetapp", fs)
+	ver, err := DetermineSDKVersion("dotnetapp.csproj", fs)
 	assert.NoError(t, err)
 	assert.Equal(t, "7.0", ver)
 }
@@ -40,7 +40,7 @@ func TestDetermineFramework_Valid(t *testing.T) {
 
 	fs := afero.NewBasePathFs(afero.NewOsFs(), path)
 
-	framework, err := DetermineFramework("dotnetapp", fs)
+	framework, err := DetermineFramework("dotnetapp.csproj", fs)
 	assert.NoError(t, err)
 	assert.Equal(t, "console", framework)
 }

--- a/internal/dotnet/templates/template.Dockerfile
+++ b/internal/dotnet/templates/template.Dockerfile
@@ -1,16 +1,19 @@
 # https://hub.docker.com/_/microsoft-dotnet
 FROM mcr.microsoft.com/dotnet/sdk:{{.DotnetVer}} AS build
 WORKDIR /source
-		
+
 # copy csproj and restore as distinct layers
+# it works only without a submodule
+{{ if .SubmoduleDir | eq "" }}
 COPY *.csproj ./
 RUN dotnet restore
-		
+{{ end }}
+
 # copy everything else and build app
 COPY . ./
-WORKDIR /source
+WORKDIR /source/{{.SubmoduleDir}}
 RUN dotnet publish -c release -o /app
-		
+
 # final stage/image
 {{ if .Static }}{{ template "nginx-runtime" . }}{{ else }}
 FROM mcr.microsoft.com/dotnet/aspnet:{{.DotnetVer}}

--- a/internal/php/plan_test.go
+++ b/internal/php/plan_test.go
@@ -14,8 +14,9 @@ import (
 // TODO: coverage of GetPHPVersion
 func TestGetPHPVersion_NoComposer(t *testing.T) {
 	fs := afero.NewMemMapFs()
+	config := plan.NewProjectConfigurationFromFs(fs, "")
 
-	v := php.GetPHPVersion(fs)
+	v := php.GetPHPVersion(config, fs)
 	assert.Equal(t, v, php.DefaultPHPVersion)
 }
 
@@ -24,8 +25,9 @@ func TestGetPHPVersion_NoVersion(t *testing.T) {
 	_ = afero.WriteFile(fs, "composer.json", []byte(`{
 		"name": "test"
 	}`), 0o644)
+	config := plan.NewProjectConfigurationFromFs(fs, "")
 
-	v := php.GetPHPVersion(fs)
+	v := php.GetPHPVersion(config, fs)
 	assert.Equal(t, v, php.DefaultPHPVersion)
 }
 
@@ -37,8 +39,9 @@ func TestGetPHPVersion_EmptyVersion(t *testing.T) {
 			"php": ""
 		}
 	}`), 0o644)
+	config := plan.NewProjectConfigurationFromFs(fs, "")
 
-	v := php.GetPHPVersion(fs)
+	v := php.GetPHPVersion(config, fs)
 	assert.Equal(t, v, php.DefaultPHPVersion)
 }
 


### PR DESCRIPTION
#### Description (required)

- Fix the tests to match new behaviors
  - [fix(planner/php): Add config to GetPHPVersion](https://github.com/zeabur/zbpack/pull/254/commits/3c2a3e6366f84b3079d9aa6717277428135be698)
  - [fix(planner/dotnet): Correct assert.Equal order](https://github.com/zeabur/zbpack/pull/254/commits/328af3e9fdfc662aea99738f876c51ee7e8c2764)
  - [test(planner/dotnet): Entrypoint contains extension now](https://github.com/zeabur/zbpack/pull/254/commits/0fa1e6ca0c4ddde252a4719cca54c930931b8830)
- Do not panic if something wrong in `PlanMeta()`
  - [fix(planner/dotnet): Fall back to other planners instead of panic](https://github.com/zeabur/zbpack/pull/254/commits/2c933a89357beab003ecc159a78cfcfcd6ebf090)
- Allow specify what project to use with `SubmoduleName`
  - [feat(planner/dotnet): Support picking project manually](https://github.com/zeabur/zbpack/pull/254/commits/194ca13904a8229cfaa37579d479a5160a97a98c)
  - [test(planner/dotnet): Add csproj match tests](https://github.com/zeabur/zbpack/pull/254/commits/aed54bcd3fcb3447d0a15ef4d978a53e282bb1ad)

#### Related issues & labels (optional)

- Closes https://github.com/zeabur/zbpack/actions/runs/8916683443/job/24488528233
- Suggested label: bug<!-- Help us triage by suggesting one of our labels that describes your PR -->
