### PR TITLE
feat(planner/dotnet): Support monorepo

### DIFF
--- a/internal/dotnet/dotnet.go
+++ b/internal/dotnet/dotnet.go
@@ -13,9 +13,10 @@ import (
 
 // TemplateContext is the context for the Dotnet Dockerfile template.
 type TemplateContext struct {
-	DotnetVer string
-	Out       string
-	Static    bool
+	DotnetVer    string
+	Out          string
+	Static       bool
+	SubmoduleDir string
 }
 
 //go:embed templates
@@ -37,8 +38,9 @@ func (c TemplateContext) Execute() (string, error) {
 // GenerateDockerfile generates the Dockerfile for Dotnet projects.
 func GenerateDockerfile(meta types.PlanMeta) (string, error) {
 	context := TemplateContext{
-		DotnetVer: meta["sdk"],
-		Out:       strings.TrimSuffix(meta["entryPoint"], ".csproj"),
+		DotnetVer:    meta["sdk"],
+		Out:          strings.TrimSuffix(meta["entryPoint"], ".csproj"),
+		SubmoduleDir: meta["submoduleDir"],
 	}
 
 	if framework := meta["framework"]; framework == "blazorwasm" {

--- a/internal/dotnet/identify.go
+++ b/internal/dotnet/identify.go
@@ -2,9 +2,13 @@ package dotnet
 
 import (
 	"errors"
+	"log"
+	"os"
 	"strings"
 
+	"github.com/samber/lo"
 	"github.com/spf13/afero"
+	"github.com/spf13/cast"
 
 	"github.com/zeabur/zbpack/internal/utils"
 	"github.com/zeabur/zbpack/pkg/plan"
@@ -23,17 +27,43 @@ func (i *identify) PlanType() types.PlanType {
 }
 
 func (i *identify) Match(fs afero.Fs) bool {
-	return utils.HasFile(fs, "Program.cs", "Startup.cs")
-}
-
-func (i *identify) findEntryPoint(fs afero.Fs, currentSubmoduleName string) (string, error) {
-	if exist, _ := afero.Exists(fs, currentSubmoduleName+".csproj"); exist {
-		return currentSubmoduleName + ".csproj", nil
+	if utils.HasFile(fs, "Program.cs", "Startup.cs") {
+		return true
 	}
 
-	files, err := afero.ReadDir(fs, ".")
+	fi, err := afero.ReadDir(fs, ".")
+	if err == nil {
+		return lo.ContainsBy(fi, func(f os.FileInfo) bool {
+			return !f.IsDir() &&
+				(strings.HasSuffix(f.Name(), ".sln") ||
+					strings.HasSuffix(f.Name(), ".csproj"))
+		})
+	}
+
+	return false
+}
+
+func (i *identify) findEntryPoint(
+	fs afero.Fs,
+	config plan.ImmutableProjectConfiguration,
+	currentSubmoduleName string,
+) (submoduleDir string, file string, err error) {
+	moduleFs := fs
+
+	if configSubmoduleDir, err := plan.Cast(
+		config.Get("dotnet.submoduleDir"), cast.ToStringE,
+	).Take(); err == nil && configSubmoduleDir != "" {
+		submoduleDir = configSubmoduleDir
+		moduleFs = afero.NewBasePathFs(fs, configSubmoduleDir)
+	}
+
+	if exist, _ := afero.Exists(moduleFs, currentSubmoduleName+".csproj"); exist {
+		return submoduleDir, currentSubmoduleName + ".csproj", nil
+	}
+
+	files, err := afero.ReadDir(moduleFs, ".")
 	if err != nil {
-		return "", err
+		return submoduleDir, "", err
 	}
 
 	for _, file := range files {
@@ -42,33 +72,42 @@ func (i *identify) findEntryPoint(fs afero.Fs, currentSubmoduleName string) (str
 		}
 
 		if strings.HasSuffix(file.Name(), ".csproj") {
-			return file.Name(), nil
+			return submoduleDir, file.Name(), nil
 		}
 	}
 
-	return "", errors.New("no .csproj file found")
+	return "", "", errors.New("no .csproj file found")
 }
 
 func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
-	entryPoint, err := i.findEntryPoint(options.Source, options.SubmoduleName)
+	submoduleDir, entryPoint, err := i.findEntryPoint(options.Source, options.Config, options.SubmoduleName)
 	if err != nil {
+		log.Printf("failed to find entrypoint: %s", err)
 		return plan.Continue()
 	}
 
-	sdkVer, err := DetermineSDKVersion(entryPoint, options.Source)
+	moduleFs := options.Source
+	if submoduleDir != "" {
+		moduleFs = afero.NewBasePathFs(options.Source, submoduleDir)
+	}
+
+	sdkVer, err := DetermineSDKVersion(entryPoint, moduleFs)
 	if err != nil {
+		log.Printf("failed to get sdk version: %s", err)
 		return plan.Continue()
 	}
 
-	framework, err := DetermineFramework(entryPoint, options.Source)
+	framework, err := DetermineFramework(entryPoint, moduleFs)
 	if err != nil {
+		log.Printf("failed to get framework: %s", err)
 		return plan.Continue()
 	}
 
 	return types.PlanMeta{
-		"sdk":        sdkVer,
-		"entryPoint": entryPoint,
-		"framework":  framework,
+		"sdk":          sdkVer,
+		"entryPoint":   entryPoint,
+		"submoduleDir": submoduleDir,
+		"framework":    framework,
 	}
 }
 

--- a/internal/dotnet/templates/template.Dockerfile
+++ b/internal/dotnet/templates/template.Dockerfile
@@ -3,8 +3,11 @@ FROM mcr.microsoft.com/dotnet/sdk:{{.DotnetVer}} AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
-COPY **.csproj ./
+# it works only without a submodule
+{{ if .SubmoduleDir | eq "" }}
+COPY *.csproj ./
 RUN dotnet restore
+{{ end }}
 
 # copy everything else and build app
 COPY . ./

--- a/internal/dotnet/templates/template.Dockerfile
+++ b/internal/dotnet/templates/template.Dockerfile
@@ -1,16 +1,16 @@
 # https://hub.docker.com/_/microsoft-dotnet
 FROM mcr.microsoft.com/dotnet/sdk:{{.DotnetVer}} AS build
 WORKDIR /source
-		
+
 # copy csproj and restore as distinct layers
-COPY *.csproj ./
+COPY **.csproj ./
 RUN dotnet restore
-		
+
 # copy everything else and build app
 COPY . ./
-WORKDIR /source
+WORKDIR /source/{{.SubmoduleDir}}
 RUN dotnet publish -c release -o /app
-		
+
 # final stage/image
 {{ if .Static }}{{ template "nginx-runtime" . }}{{ else }}
 FROM mcr.microsoft.com/dotnet/aspnet:{{.DotnetVer}}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Add a `dotnet.submoduleDir` configuration that allows specify the module directory manually without changing the Docker context directory.

Tested:
- `dotnetapp/dotnetapp.csproj`
- `dotnetapp/dotnetapp/dotnetapp.csproj` (with the first `dotnetapp` as submodule name, the second `dotnetapp` as submodule directory)
- `myexampleproject/dotnetapp/dotnetapp.csproj` (with the first `myexampleproject` as submodule name, the second `dotnetapp` as submodule directory)

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-2931<!-- Add an issue number if this PR will close it. -->
- Suggested label: `enhancement`<!-- Help us triage by suggesting one of our labels that describes your PR -->
