### PR TITLE
fix(nodejs): cleanup devDeps after build

### DIFF
--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -500,15 +500,15 @@ func GetBuildCmd(ctx *nodePlanContext) string {
 	var buildCmd string
 	switch pkgManager {
 	case types.NodePackageManagerPnpm:
-		buildCmd = "pnpm run " + buildScript
+		buildCmd = "RUN pnpm run " + buildScript + "\nRUN rm -rf node_modules && pnpm install --production"
 	case types.NodePackageManagerNpm:
-		buildCmd = "npm run " + buildScript
+		buildCmd = "RUN npm run " + buildScript + "\nRUN rm -rf node_modules && npm install --omit=dev"
 	case types.NodePackageManagerBun:
-		buildCmd = "bun run " + buildScript
+		buildCmd = "RUN bun run " + buildScript + "\nRUN rm -rf node_modules && bun install --production"
 	case types.NodePackageManagerYarn:
 		fallthrough
 	default:
-		buildCmd = "yarn " + buildScript
+		buildCmd = "RUN yarn " + buildScript + "\nRUN rm -rf node_modules && yarn install --production"
 	}
 
 	if buildScript == "" {
@@ -731,7 +731,7 @@ func GetMeta(opt GetMetaOptions) types.PlanMeta {
 
 	buildCmd := GetBuildCmd(ctx)
 	if opt.CustomBuildCmd != nil && *opt.CustomBuildCmd != "" {
-		buildCmd = *opt.CustomBuildCmd
+		buildCmd = "RUN " + *opt.CustomBuildCmd
 	}
 	meta["buildCmd"] = buildCmd
 

--- a/internal/nodejs/template_test.go
+++ b/internal/nodejs/template_test.go
@@ -65,7 +65,7 @@ func TestTemplate_BuildCmd_NOutputDir(t *testing.T) {
 		NodeVersion: "18",
 
 		InstallCmd: "RUN yarn install",
-		BuildCmd:   "yarn build",
+		BuildCmd:   "RUN yarn build",
 		StartCmd:   "yarn start",
 	}
 
@@ -79,7 +79,7 @@ func TestTemplate_BuildCmd_OutputDir(t *testing.T) {
 		NodeVersion: "18",
 
 		InstallCmd: "RUN yarn install",
-		BuildCmd:   "yarn build",
+		BuildCmd:   "RUN yarn build",
 		StartCmd:   "yarn start",
 	}
 

--- a/internal/nodejs/templates/template.Dockerfile
+++ b/internal/nodejs/templates/template.Dockerfile
@@ -29,7 +29,7 @@ ENV NITRO_PRESET=node
 ENV NITRO_PRESET=node-server
 {{ end }}
 # Build if we can build it
-{{ if .BuildCmd }}RUN {{ .BuildCmd }}{{ end }}
+{{ if .BuildCmd }}{{ .BuildCmd }}{{ end }}
 {{ if .Serverless }}
 FROM scratch as output
 COPY --from=build /src /


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

<!-- Please describe the change you are proposing, and why -->

Reinstall node_modules with `--production` flag after build. 

So we can cleanup the dependencies which is unused in runtime.

#### Related issues & labels (optional)

- Closes #<!-- Add an issue number if this PR will close it. -->
- Suggested label: <!-- Help us triage by suggesting one of our labels that describes your PR -->
