### PR TITLE
ZEA-3167: Node.js: Customize InstallCommand

### DIFF
--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/moznion/go-optional"
 	"github.com/spf13/afero"
+	"github.com/spf13/cast"
 	"github.com/zeabur/zbpack/internal/utils"
 	"github.com/zeabur/zbpack/pkg/plan"
 	"github.com/zeabur/zbpack/pkg/types"
@@ -443,9 +444,15 @@ func GetInstallCmd(ctx *nodePlanContext) string {
 	pkgManager := DeterminePackageManager(ctx)
 	shouldCacheDependencies := plan.Cast(ctx.Config.Get(ConfigCacheDependencies), plan.ToWeakBoolE).TakeOr(true)
 
-	// monorepo
+	// disable cache_dependencies for monorepos
 	if shouldCacheDependencies && utils.HasFile(src, "pnpm-workspace.yaml", "pnpm-workspace.yml", "packages") {
 		log.Println("Detected Monorepo. Disabling dependency caching.")
+		shouldCacheDependencies = false
+	}
+
+	// disable cache_dependencies if the installation command is customized
+	installCmdConf := plan.Cast(ctx.Config.Get(plan.ConfigInstallCommand), cast.ToStringE)
+	if installCmdConf.IsSome() {
 		shouldCacheDependencies = false
 	}
 
@@ -459,17 +466,21 @@ func GetInstallCmd(ctx *nodePlanContext) string {
 		cmds = append(cmds, "COPY . .")
 	}
 
-	switch pkgManager {
-	case types.NodePackageManagerNpm:
-		cmds = append(cmds, "COPY package-lock.json* .", "RUN npm install")
-	case types.NodePackageManagerPnpm:
-		cmds = append(cmds, "COPY pnpm-lock.yaml* .", "RUN pnpm install")
-	case types.NodePackageManagerBun:
-		cmds = append(cmds, "COPY bun.lockb* .", "RUN bun install")
-	case types.NodePackageManagerYarn:
-		cmds = append(cmds, "COPY yarn.lock* .", "RUN yarn install")
-	default:
-		cmds = append(cmds, "RUN yarn install")
+	if installCmd, err := installCmdConf.Take(); err == nil {
+		cmds = append(cmds, installCmd)
+	} else {
+		switch pkgManager {
+		case types.NodePackageManagerNpm:
+			cmds = append(cmds, "COPY package-lock.json* .", "RUN npm install")
+		case types.NodePackageManagerPnpm:
+			cmds = append(cmds, "COPY pnpm-lock.yaml* .", "RUN pnpm install")
+		case types.NodePackageManagerBun:
+			cmds = append(cmds, "COPY bun.lockb* .", "RUN bun install")
+		case types.NodePackageManagerYarn:
+			cmds = append(cmds, "COPY yarn.lock* .", "RUN yarn install")
+		default:
+			cmds = append(cmds, "RUN yarn install")
+		}
 	}
 
 	needPlaywright := DetermineNeedPlaywright(ctx)

--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -4,7 +4,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/zbpack/pkg/plan"
 )
 
 func TestGetNodeVersion_Empty(t *testing.T) {
@@ -80,4 +82,81 @@ func TestGetNodeVersion_NvmRcLatest(t *testing.T) {
 func TestGetNodeVersion_VPrefixedVersion(t *testing.T) {
 	v := getNodeVersion("v20.11.0")
 	assert.Equal(t, "20.11", v)
+}
+
+func TestGetInstallCmd_CustomizeInstallCmd(t *testing.T) {
+	src := afero.NewMemMapFs()
+	_ = afero.WriteFile(src, "package.json", []byte(`{}`), 0o644)
+
+	config := plan.NewProjectConfigurationFromFs(src, "")
+	config.Set(plan.ConfigInstallCommand, "echo 'installed'")
+
+	packageJSON, err := DeserializePackageJSON(src)
+	assert.NoError(t, err)
+
+	ctx := &nodePlanContext{
+		PackageJSON: packageJSON,
+		Config:      config,
+		Src:         src,
+	}
+	installlCmd := GetInstallCmd(ctx)
+
+	// for customized installation command, no cache are allowed.
+	assert.Contains(t, installlCmd, "COPY . .")
+
+	// the installation command should be contained
+	assert.Contains(t, installlCmd, "echo 'installed'")
+}
+
+func TestGetInstallCmd_DefaultInstallCmd(t *testing.T) {
+	src := afero.NewMemMapFs()
+	_ = afero.WriteFile(src, "package.json", []byte(`{}`), 0o644)
+	_ = afero.WriteFile(src, "yarn.lock", []byte(``), 0o644)
+
+	config := plan.NewProjectConfigurationFromFs(src, "")
+
+	packageJSON, err := DeserializePackageJSON(src)
+	assert.NoError(t, err)
+
+	ctx := &nodePlanContext{
+		PackageJSON: packageJSON,
+		Config:      config,
+		Src:         src,
+	}
+
+	installlCmd := GetInstallCmd(ctx)
+
+	// for default installation command, cache are allowed.
+	assert.Contains(t, installlCmd, "COPY yarn.lock* .")
+
+	// the installation command should be contained
+	assert.Contains(t, installlCmd, "yarn install")
+}
+
+func TestGetInstallCmd_CustomizeInstallCmdDeps(t *testing.T) {
+	src := afero.NewMemMapFs()
+	_ = afero.WriteFile(src, "package.json", []byte(`{
+	"dependencies": {
+		"playwright-chromium": "*"
+	}
+}`), 0o644)
+
+	config := plan.NewProjectConfigurationFromFs(src, "")
+	config.Set(plan.ConfigInstallCommand, "echo 'installed'")
+
+	packageJSON, err := DeserializePackageJSON(src)
+	assert.NoError(t, err)
+
+	ctx := &nodePlanContext{
+		PackageJSON: packageJSON,
+		Config:      config,
+		Src:         src,
+	}
+	installlCmd := GetInstallCmd(ctx)
+
+	// the playwright dependencies should be installed
+	assert.Contains(t, installlCmd, "libnss3 libatk1.0-0 libatk-bridge2.0-0")
+
+	// the installation command should be contained
+	assert.Contains(t, installlCmd, "echo 'installed'")
 }

--- a/pkg/plan/config.go
+++ b/pkg/plan/config.go
@@ -170,6 +170,8 @@ func Cast[T any](value optional.Option[any], caster func(any) (T, error)) option
 
 // Common configuration keys.
 const (
+	// ConfigInstallCommand is the key for the installation command in the project configuration.
+	ConfigInstallCommand = "install_command"
 	// ConfigBuildCommand is the key for the build command in the project configuration.
 	ConfigBuildCommand = "build_command"
 	// ConfigStartCommand is the key for the start command in the project configuration.

--- a/pkg/types/plan.go
+++ b/pkg/types/plan.go
@@ -85,7 +85,7 @@ const (
 	NodeProjectFrameworkNueJs            NodeProjectFramework = "nuejs"
 	NodeProjectFrameworkVocs             NodeProjectFramework = "vocs"
 	NodeProjectFrameworkRspress          NodeProjectFramework = "rspress"
-	NodeProjectFrameworkGrammY		   	 NodeProjectFramework = "grammy"
+	NodeProjectFrameworkGrammY           NodeProjectFramework = "grammy"
 )
 
 //revive:enable:exported


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)


- **feat(planner): Add `install_command` configuration**
- **feat(planner/nodejs): Implement `install_command`**
	* No cache in `install_command`.
	* `install_command` overrides the package manager installation commands, such as `yarn install`
	* Dependencies are still installed.
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-3167<!-- Add an issue number if this PR will close it. -->
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
