### PR TITLE
ZEA-3340: support python_version field in pipenv

### DIFF
--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -586,6 +586,8 @@ func determinePythonVersion(ctx *pythonPlanContext) string {
 		return determinePythonVersionWithPdm(ctx)
 	case types.PythonPackageManagerRye:
 		return determinePythonVersionWithRye(ctx)
+	case types.PythonPackageManagerPipenv:
+		return determinePythonVersionWithPipenv(ctx)
 	default:
 		return defaultPython3Version
 	}
@@ -645,6 +647,23 @@ func determinePythonVersionWithRye(ctx *pythonPlanContext) string {
 	match := regex.FindSubmatch(content)
 	if len(match) > 1 {
 		return getPython3Version(string(match[1]))
+	}
+
+	return defaultPython3Version
+}
+
+func determinePythonVersionWithPipenv(ctx *pythonPlanContext) string {
+	src := ctx.Src
+
+	content, err := afero.ReadFile(src, "Pipfile")
+	if err != nil {
+		return defaultPython3Version
+	}
+
+	compile := regexp.MustCompile(`python_version\s*=\s*"(.*?)"`)
+	submatchs := compile.FindStringSubmatch(string(content))
+	if len(submatchs) > 1 {
+		return submatchs[1]
 	}
 
 	return defaultPython3Version


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

When detecting `python_version` in Pipfile, we pick that `python_version` to deploy.

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-3340<!-- Add an issue number if this PR will close it. -->
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
