### PR TITLE
ZEA-3339: Support python.version configuration

### DIFF
--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -35,6 +35,10 @@ const (
 	// ConfigStreamlitEntry is the key for specifying the streamlit entry explicitly
 	// in the project configuration.
 	ConfigStreamlitEntry = "streamlit.entry"
+
+	// ConfigPythonVersion is the key for specifying the Python version explicitly
+	// in the project configuration.
+	ConfigPythonVersion = "python.version"
 )
 
 // DetermineFramework determines the framework of the Python project.
@@ -577,6 +581,10 @@ func determineStartCmd(ctx *pythonPlanContext) string {
 
 // determinePythonVersion Determine Python Version
 func determinePythonVersion(ctx *pythonPlanContext) string {
+	if pythonVersion, err := plan.Cast(ctx.Config.Get(ConfigPythonVersion), cast.ToStringE).Take(); err == nil {
+		return getPython3Version(pythonVersion)
+	}
+
 	pm := DeterminePackageManager(ctx)
 
 	switch pm {

--- a/internal/python/plan_test.go
+++ b/internal/python/plan_test.go
@@ -1006,10 +1006,24 @@ python_version = "3.12"
 			_ = afero.WriteFile(fs, "Pipfile", []byte(p.content), 0o644)
 
 			ctx := &pythonPlanContext{
-				Src: fs,
+				Src:    fs,
+				Config: plan.NewProjectConfigurationFromFs(fs, ""),
 			}
 
 			assert.Equal(t, p.expect, determinePythonVersion(ctx))
 		})
 	}
+}
+
+func TestDeterminePythonVersion_Customized(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	conf := plan.NewProjectConfigurationFromFs(fs, "")
+	conf.Set(ConfigPythonVersion, "3.12345.1")
+
+	ctx := &pythonPlanContext{
+		Src:    fs,
+		Config: conf,
+	}
+
+	assert.Equal(t, "3.12345", determinePythonVersion(ctx))
 }


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Allow setting the Python version with `ZBPACK_PYTHON_VERSION` or

```json
{
  "python": {
    "version": "3.12"
  }
}
```
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-3339<!-- Add an issue number if this PR will close it. -->
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
