### PR TITLE
ZEA-3468: Node.js Monorepo Native Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,11 @@ require (
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/fatih/color v1.17.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gkampitakis/ciinfo v0.3.0 // indirect
 	github.com/gkampitakis/go-diff v1.3.2 // indirect
+	github.com/goccy/go-yaml v1.11.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -28,6 +30,8 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/maruel/natural v1.1.1 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
@@ -47,7 +51,8 @@ require (
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 // indirect
 	golang.org/x/sync v0.7.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/sys v0.21.0 // indirect
+	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/evanw/esbuild v0.21.5 h1:oShm8TT5QUhf6vM7teg0nmd14eHu64dPmVluC2f4DMg=
 github.com/evanw/esbuild v0.21.5/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfVQuRi48=
+github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
+github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
@@ -34,6 +36,8 @@ github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZ
 github.com/gkampitakis/go-diff v1.3.2/go.mod h1:LLgOrpqleQe26cte8s36HTWcTmMEur6OPYerdAAS9tk=
 github.com/gkampitakis/go-snaps v0.5.4 h1:GX+dkKmVsRenz7SoTbdIEL4KQARZctkMiZ8ZKprRwT8=
 github.com/gkampitakis/go-snaps v0.5.4/go.mod h1:ZABkO14uCuVxBHAXAfKG+bqNz+aa1bGPAg8jkI0Nk8Y=
+github.com/goccy/go-yaml v1.11.3 h1:B3W9IdWbvrUu2OYQGwvU1nZtvMQJPBKgBUuweJjLj6I=
+github.com/goccy/go-yaml v1.11.3/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -74,7 +78,12 @@ github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3v
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-colorable v0.0.6/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.0-20160806122752-66b8e73f3f5c/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -176,6 +185,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -183,6 +193,8 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
@@ -202,6 +214,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=

--- a/internal/nodejs/__snapshots__/template_test.snap
+++ b/internal/nodejs/__snapshots__/template_test.snap
@@ -48,8 +48,9 @@ COPY . .
 # Build if we can build it
 RUN yarn build
 
-EXPOSE 8080
-CMD yarn start
+FROM scratch as output
+COPY --from=build /src/ /
+
 
 ---
 
@@ -72,8 +73,86 @@ COPY . .
 # Build if we can build it
 RUN yarn build
 
+FROM scratch as output
+COPY --from=build /src///app/dist /
+
+
+---
+
+[TestTemplate_Monorepo - 1]
+FROM node:18 as build
+
+ENV PORT=8080
+WORKDIR /src
+
+# Check if we have 'corepack' available; if none, we
+# install corepack@0.10.0.
+RUN which corepack || npm install -g --force corepack@0.10.0
+RUN corepack enable
+
+WORKDIR /src/myservice
+RUN yarn install
+
+
+
+
+# Build if we can build it
+
+
 EXPOSE 8080
 CMD yarn start
+
+---
+
+[TestTemplate_MonorepoServerless - 1]
+FROM node:18 as build
+
+ENV PORT=8080
+WORKDIR /src
+
+# Check if we have 'corepack' available; if none, we
+# install corepack@0.10.0.
+RUN which corepack || npm install -g --force corepack@0.10.0
+RUN corepack enable
+
+WORKDIR /src/myservice
+RUN yarn install
+
+
+
+
+# Build if we can build it
+
+
+FROM scratch as output
+COPY --from=build /src/myservice /
+
+
+---
+
+[TestTemplate_MonorepoServerlessOutDir - 1]
+FROM node:18 as build
+
+ENV PORT=8080
+WORKDIR /src
+
+# Check if we have 'corepack' available; if none, we
+# install corepack@0.10.0.
+RUN which corepack || npm install -g --force corepack@0.10.0
+RUN corepack enable
+
+WORKDIR /src/myservice
+RUN yarn install
+
+
+
+
+# Build if we can build it
+
+
+FROM scratch as output
+COPY --from=build /src/myservice//app/dist /
+
 
 ---
 

--- a/internal/nodejs/node.go
+++ b/internal/nodejs/node.go
@@ -14,6 +14,8 @@ import (
 type TemplateContext struct {
 	NodeVersion string
 
+	ServiceDir string
+
 	InstallCmd string
 	BuildCmd   string
 	StartCmd   string
@@ -44,6 +46,7 @@ func (c TemplateContext) Execute() (string, error) {
 func getContextBasedOnMeta(meta types.PlanMeta) TemplateContext {
 	context := TemplateContext{
 		NodeVersion: meta["nodeVersion"],
+		ServiceDir:  meta["serviceDir"],
 		InstallCmd:  meta["installCmd"],
 		BuildCmd:    meta["buildCmd"],
 		StartCmd:    meta["startCmd"],

--- a/internal/nodejs/node.go
+++ b/internal/nodejs/node.go
@@ -14,7 +14,7 @@ import (
 type TemplateContext struct {
 	NodeVersion string
 
-	ServiceDir string
+	AppDir string
 
 	InstallCmd string
 	BuildCmd   string
@@ -46,7 +46,7 @@ func (c TemplateContext) Execute() (string, error) {
 func getContextBasedOnMeta(meta types.PlanMeta) TemplateContext {
 	context := TemplateContext{
 		NodeVersion: meta["nodeVersion"],
-		ServiceDir:  meta["serviceDir"],
+		AppDir:      meta["appDir"],
 		InstallCmd:  meta["installCmd"],
 		BuildCmd:    meta["buildCmd"],
 		StartCmd:    meta["startCmd"],

--- a/internal/nodejs/package.go
+++ b/internal/nodejs/package.go
@@ -22,6 +22,9 @@ type PackageJSON struct {
 	Engines         PackageJSONEngine `json:"engines"`
 	Main            string            `json:"main"`
 	Module          string            `json:"module"`
+
+	// yarn workspace
+	Workspaces []string `json:"workspaces,omitempty"`
 }
 
 // NewPackageJSON returns a new instance of PackageJson

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -527,13 +527,26 @@ func GetInstallCmd(ctx *nodePlanContext) string {
 	} else {
 		switch pkgManager {
 		case types.NodePackageManagerNpm:
-			cmds = append(cmds, "COPY package-lock.json* .", "RUN npm install")
+			// FIXME: reldir != ""
+			if shouldCacheDependencies && reldir == "" {
+				cmds = append(cmds, "COPY package-lock.json* .")
+			}
+			cmds = append(cmds, "RUN npm install")
 		case types.NodePackageManagerPnpm:
-			cmds = append(cmds, "COPY pnpm-lock.yaml* .", "RUN pnpm install")
+			if shouldCacheDependencies && reldir == "" {
+				cmds = append(cmds, "COPY pnpm-lock.yaml* .")
+			}
+			cmds = append(cmds, "RUN pnpm install")
 		case types.NodePackageManagerBun:
-			cmds = append(cmds, "COPY bun.lockb* .", "RUN bun install")
+			if shouldCacheDependencies && reldir == "" {
+				cmds = append(cmds, "COPY bun.lockb* .")
+			}
+			cmds = append(cmds, "RUN bun install")
 		case types.NodePackageManagerYarn:
-			cmds = append(cmds, "COPY yarn.lock* .", "RUN yarn install")
+			if shouldCacheDependencies && reldir == "" {
+				cmds = append(cmds, "COPY yarn.lock* .")
+			}
+			cmds = append(cmds, "RUN yarn install")
 		default:
 			cmds = append(cmds, "RUN yarn install")
 		}

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -89,7 +89,7 @@ func (ctx *nodePlanContext) GetServicePackageJSON() PackageJSON {
 
 // DeterminePackageManager determines the package manager of the Node.js project.
 func DeterminePackageManager(ctx *nodePlanContext) types.NodePackageManager {
-	src, _ := ctx.GetServiceSource()
+	src := ctx.Src
 	pm := &ctx.PackageManager
 	packageJSON := ctx.ProjectPackageJSON
 
@@ -149,8 +149,8 @@ func DeterminePackageManager(ctx *nodePlanContext) types.NodePackageManager {
 	return pm.Unwrap()
 }
 
-// DetermineProjectFramework determines the framework of the Node.js project.
-func DetermineProjectFramework(ctx *nodePlanContext) types.NodeProjectFramework {
+// DetermineServiceFramework determines the framework of the Node.js service.
+func DetermineServiceFramework(ctx *nodePlanContext) types.NodeProjectFramework {
 	fw := &ctx.Framework
 	packageJSON := ctx.GetServicePackageJSON()
 
@@ -311,7 +311,7 @@ func DetermineProjectFramework(ctx *nodePlanContext) types.NodeProjectFramework 
 	return fw.Unwrap()
 }
 
-// DetermineNeedPuppeteer determines whether the project needs Puppeteer.
+// DetermineNeedPuppeteer determines whether the service needs Puppeteer.
 func DetermineNeedPuppeteer(ctx *nodePlanContext) bool {
 	pup := &ctx.NeedPuppeteer
 	servicePackageJSON := ctx.GetServicePackageJSON()
@@ -329,7 +329,7 @@ func DetermineNeedPuppeteer(ctx *nodePlanContext) bool {
 	return pup.Unwrap()
 }
 
-// DetermineNeedPlaywright determines whether the project needs Playwright.
+// DetermineNeedPlaywright determines whether the service needs Playwright.
 func DetermineNeedPlaywright(ctx *nodePlanContext) bool {
 	pw := &ctx.NeedPlaywright
 	packageJSON := ctx.GetServicePackageJSON()
@@ -352,7 +352,7 @@ func DetermineNeedPlaywright(ctx *nodePlanContext) bool {
 	return pw.Unwrap()
 }
 
-// GetBuildScript gets the build command in package.json's `scripts` of the Node.js project.
+// GetBuildScript gets the build command in package.json's `scripts` of the Node.js service.
 func GetBuildScript(ctx *nodePlanContext) string {
 	bs := &ctx.BuildScript
 	packageJSON := ctx.GetServicePackageJSON()
@@ -377,7 +377,7 @@ func GetBuildScript(ctx *nodePlanContext) string {
 	return bs.Unwrap()
 }
 
-// GetStartScript gets the start command in package.json's `scripts` of the Node.js project.
+// GetStartScript gets the start command in package.json's `scripts` of the Node.js service.
 func GetStartScript(ctx *nodePlanContext) string {
 	src, _ := ctx.GetServiceSource()
 	ss := &ctx.StartScript
@@ -467,7 +467,7 @@ func GetNodeVersion(ctx *nodePlanContext) string {
 	return getNodeVersion(projectNodeVersion)
 }
 
-// GetEntry gets the entry file of the Node.js project.
+// GetEntry gets the entry file of the Node.js service.
 func GetEntry(ctx *nodePlanContext) string {
 	packageJSON := ctx.GetServicePackageJSON()
 	ent := &ctx.Entry
@@ -480,7 +480,7 @@ func GetEntry(ctx *nodePlanContext) string {
 	return ent.Unwrap()
 }
 
-// GetInstallCmd gets the installation command of the Node.js project.
+// GetInstallCmd gets the installation command of the Node.js service.
 func GetInstallCmd(ctx *nodePlanContext) string {
 	cmd := &ctx.InstallCmd
 	src, _ := ctx.GetServiceSource()
@@ -550,7 +550,7 @@ func GetInstallCmd(ctx *nodePlanContext) string {
 	return cmd.Unwrap()
 }
 
-// GetBuildCmd gets the build command of the Node.js project.
+// GetBuildCmd gets the build command of the Node.js service.
 func GetBuildCmd(ctx *nodePlanContext) string {
 	cmd := &ctx.BuildCmd
 
@@ -679,7 +679,7 @@ func FindServiceDirByGlob(fs afero.Fs, pattern string) (match string, fnerr erro
 	return "", fnerr
 }
 
-// GetStartCmd gets the start command of the Node.js project.
+// GetStartCmd gets the start command of the Node.js service.
 func GetStartCmd(ctx *nodePlanContext) string {
 	cmd := &ctx.StartCmd
 
@@ -695,7 +695,7 @@ func GetStartCmd(ctx *nodePlanContext) string {
 	startScript := GetStartScript(ctx)
 	pkgManager := DeterminePackageManager(ctx)
 	entry := GetEntry(ctx)
-	framework := DetermineProjectFramework(ctx)
+	framework := DetermineServiceFramework(ctx)
 
 	var startCmd string
 	switch pkgManager {
@@ -739,7 +739,7 @@ func GetStartCmd(ctx *nodePlanContext) string {
 	return cmd.Unwrap()
 }
 
-// GetStaticOutputDir returns the output directory for static projects.
+// GetStaticOutputDir returns the output directory for static service.
 // If empty string is returned, the service is not deployed as static files.
 func GetStaticOutputDir(ctx *nodePlanContext) string {
 	dir := &ctx.StaticOutputDir
@@ -749,7 +749,7 @@ func GetStaticOutputDir(ctx *nodePlanContext) string {
 		return outputDir
 	}
 
-	framework := DetermineProjectFramework(ctx)
+	framework := DetermineServiceFramework(ctx)
 
 	// the default output directory of Angular is `dist/<project-name>/browser`
 	// we need to find the project name from `angular.json`.
@@ -825,7 +825,7 @@ func getServerless(ctx *nodePlanContext) bool {
 		return serverless
 	}
 
-	framework := DetermineProjectFramework(ctx)
+	framework := DetermineServiceFramework(ctx)
 
 	defaultServerless := map[types.NodeProjectFramework]bool{
 		types.NodeProjectFrameworkNextJs:  true,
@@ -880,7 +880,7 @@ func GetMeta(opt GetMetaOptions) types.PlanMeta {
 	pkgManager := DeterminePackageManager(ctx)
 	meta["packageManager"] = string(pkgManager)
 
-	framework := DetermineProjectFramework(ctx)
+	framework := DetermineServiceFramework(ctx)
 	meta["framework"] = string(framework)
 
 	nodeVersion := GetNodeVersion(ctx)

--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -95,9 +95,9 @@ func TestGetInstallCmd_CustomizeInstallCmd(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := &nodePlanContext{
-		PackageJSON: packageJSON,
-		Config:      config,
-		Src:         src,
+		ProjectPackageJSON: packageJSON,
+		Config:             config,
+		Src:                src,
 	}
 	installlCmd := GetInstallCmd(ctx)
 
@@ -122,9 +122,9 @@ func TestGetInstallCmd_DefaultInstallCmd(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := &nodePlanContext{
-		PackageJSON: packageJSON,
-		Config:      config,
-		Src:         src,
+		ProjectPackageJSON: packageJSON,
+		Config:             config,
+		Src:                src,
 	}
 
 	installlCmd := GetInstallCmd(ctx)
@@ -154,9 +154,9 @@ func TestGetInstallCmd_CustomizeInstallCmdDeps(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := &nodePlanContext{
-		PackageJSON: packageJSON,
-		Config:      config,
-		Src:         src,
+		ProjectPackageJSON: packageJSON,
+		Config:             config,
+		Src:                src,
 	}
 	installlCmd := GetInstallCmd(ctx)
 

--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -189,7 +189,7 @@ func TestGetMonorepoServiceRoot(t *testing.T) {
 			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
 		}
 
-		serviceRoot := GetMonorepoServiceRoot(ctx)
+		serviceRoot := GetMonorepoAppRoot(ctx)
 		assert.Equal(t, "packages/service1", serviceRoot)
 	})
 
@@ -208,7 +208,7 @@ func TestGetMonorepoServiceRoot(t *testing.T) {
 			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
 		}
 
-		serviceRoot := GetMonorepoServiceRoot(ctx)
+		serviceRoot := GetMonorepoAppRoot(ctx)
 		assert.Equal(t, "apps/service1", serviceRoot)
 	})
 
@@ -226,7 +226,7 @@ func TestGetMonorepoServiceRoot(t *testing.T) {
 			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
 		}
 
-		serviceRoot := GetMonorepoServiceRoot(ctx)
+		serviceRoot := GetMonorepoAppRoot(ctx)
 		assert.Equal(t, "packages/service1", serviceRoot)
 	})
 
@@ -238,7 +238,7 @@ func TestGetMonorepoServiceRoot(t *testing.T) {
 		_ = afero.WriteFile(fs, "services/service1/package.json", []byte(`{}`), 0o644)
 
 		config := plan.NewProjectConfigurationFromFs(fs, "")
-		config.Set(ConfigServicePath, "services/service1")
+		config.Set(ConfigAppDir, "services/service1")
 
 		ctx := &nodePlanContext{
 			Src:                fs,
@@ -246,7 +246,7 @@ func TestGetMonorepoServiceRoot(t *testing.T) {
 			Config:             config,
 		}
 
-		serviceRoot := GetMonorepoServiceRoot(ctx)
+		serviceRoot := GetMonorepoAppRoot(ctx)
 		assert.Equal(t, "services/service1", serviceRoot)
 	})
 }
@@ -265,7 +265,7 @@ func TestNodePlanContext_GetServiceSource(t *testing.T) {
 			Config:             plan.NewProjectConfigurationFromFs(fs, ""),
 			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
 		}
-		fs, reldir := ctx.GetServiceSource()
+		fs, reldir := ctx.GetAppSource()
 
 		assert.Equal(t, "", reldir)
 		packageJSON, err := DeserializePackageJSON(fs)
@@ -288,7 +288,7 @@ func TestNodePlanContext_GetServiceSource(t *testing.T) {
 			Config:             plan.NewProjectConfigurationFromFs(fs, ""),
 			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
 		}
-		fs, reldir := ctx.GetServiceSource()
+		fs, reldir := ctx.GetAppSource()
 
 		assert.Equal(t, "packages/service1", reldir)
 		packageJSON, err := DeserializePackageJSON(fs)
@@ -312,7 +312,7 @@ func TestNodePlanContext_GetServicePackageJSON(t *testing.T) {
 			Config:             plan.NewProjectConfigurationFromFs(fs, ""),
 			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
 		}
-		packageJSON := ctx.GetServicePackageJSON()
+		packageJSON := ctx.GetAppPackageJSON()
 		assert.Equal(t, "main.js", packageJSON.Main)
 	})
 
@@ -330,7 +330,7 @@ func TestNodePlanContext_GetServicePackageJSON(t *testing.T) {
 			Config:             plan.NewProjectConfigurationFromFs(fs, ""),
 			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
 		}
-		packageJSON := ctx.GetServicePackageJSON()
+		packageJSON := ctx.GetAppPackageJSON()
 		assert.Equal(t, "service1.js", packageJSON.Main)
 	})
 }

--- a/internal/nodejs/template_test.go
+++ b/internal/nodejs/template_test.go
@@ -67,6 +67,8 @@ func TestTemplate_BuildCmd_NOutputDir(t *testing.T) {
 		InstallCmd: "RUN yarn install",
 		BuildCmd:   "yarn build",
 		StartCmd:   "yarn start",
+
+		Serverless: true,
 	}
 
 	result, err := ctx.Execute()
@@ -81,6 +83,8 @@ func TestTemplate_BuildCmd_OutputDir(t *testing.T) {
 		InstallCmd: "RUN yarn install",
 		BuildCmd:   "yarn build",
 		StartCmd:   "yarn start",
+
+		OutputDir: "/app/dist",
 	}
 
 	result, err := ctx.Execute()
@@ -94,6 +98,47 @@ func TestTemplate_BuildCmd_Bun(t *testing.T) {
 		NodeVersion: "18",
 		InstallCmd:  "RUN bun install",
 		StartCmd:    "bun start main.ts",
+	}
+
+	result, err := ctx.Execute()
+	assert.NoError(t, err)
+	snaps.MatchSnapshot(t, result)
+}
+
+func TestTemplate_Monorepo(t *testing.T) {
+	ctx := nodejs.TemplateContext{
+		NodeVersion: "18",
+		ServiceDir:  "myservice",
+		InstallCmd:  "WORKDIR /src/myservice\nRUN yarn install",
+		StartCmd:    "yarn start",
+	}
+
+	result, err := ctx.Execute()
+	assert.NoError(t, err)
+	snaps.MatchSnapshot(t, result)
+}
+
+func TestTemplate_MonorepoServerless(t *testing.T) {
+	ctx := nodejs.TemplateContext{
+		NodeVersion: "18",
+		ServiceDir:  "myservice",
+		InstallCmd:  "WORKDIR /src/myservice\nRUN yarn install",
+		StartCmd:    "yarn start",
+		Serverless:  true,
+	}
+
+	result, err := ctx.Execute()
+	assert.NoError(t, err)
+	snaps.MatchSnapshot(t, result)
+}
+
+func TestTemplate_MonorepoServerlessOutDir(t *testing.T) {
+	ctx := nodejs.TemplateContext{
+		NodeVersion: "18",
+		ServiceDir:  "myservice",
+		InstallCmd:  "WORKDIR /src/myservice\nRUN yarn install",
+		StartCmd:    "yarn start",
+		OutputDir:   "/app/dist",
 	}
 
 	result, err := ctx.Execute()

--- a/internal/nodejs/template_test.go
+++ b/internal/nodejs/template_test.go
@@ -108,7 +108,7 @@ func TestTemplate_BuildCmd_Bun(t *testing.T) {
 func TestTemplate_Monorepo(t *testing.T) {
 	ctx := nodejs.TemplateContext{
 		NodeVersion: "18",
-		ServiceDir:  "myservice",
+		AppDir:      "myservice",
 		InstallCmd:  "WORKDIR /src/myservice\nRUN yarn install",
 		StartCmd:    "yarn start",
 	}
@@ -121,7 +121,7 @@ func TestTemplate_Monorepo(t *testing.T) {
 func TestTemplate_MonorepoServerless(t *testing.T) {
 	ctx := nodejs.TemplateContext{
 		NodeVersion: "18",
-		ServiceDir:  "myservice",
+		AppDir:      "myservice",
 		InstallCmd:  "WORKDIR /src/myservice\nRUN yarn install",
 		StartCmd:    "yarn start",
 		Serverless:  true,
@@ -135,7 +135,7 @@ func TestTemplate_MonorepoServerless(t *testing.T) {
 func TestTemplate_MonorepoServerlessOutDir(t *testing.T) {
 	ctx := nodejs.TemplateContext{
 		NodeVersion: "18",
-		ServiceDir:  "myservice",
+		AppDir:      "myservice",
 		InstallCmd:  "WORKDIR /src/myservice\nRUN yarn install",
 		StartCmd:    "yarn start",
 		OutputDir:   "/app/dist",

--- a/internal/nodejs/templates/template.Dockerfile
+++ b/internal/nodejs/templates/template.Dockerfile
@@ -21,7 +21,7 @@ RUN corepack enable
 
 {{ .InstallCmd }}
 
-COPY . .
+{{ if eq .ServiceDir "" }}COPY . .{{ end }}
 {{ if and (eq .Framework "nuxt.js") .Serverless }}
 ENV NITRO_PRESET=node
 {{ end }}
@@ -32,10 +32,10 @@ ENV NITRO_PRESET=node-server
 {{ if .BuildCmd }}RUN {{ .BuildCmd }}{{ end }}
 {{ if .Serverless }}
 FROM scratch as output
-COPY --from=build /src /
+COPY --from=build /src/{{ .ServiceDir }} /
 {{ else if ne .OutputDir "" }}
 FROM scratch as output
-COPY --from=build /src/{{ .OutputDir }} /
+COPY --from=build /src/{{ .ServiceDir }}/{{ .OutputDir }} /
 {{ else }}
 EXPOSE 8080
 CMD {{ .StartCmd }}{{ end }}

--- a/internal/nodejs/templates/template.Dockerfile
+++ b/internal/nodejs/templates/template.Dockerfile
@@ -21,7 +21,7 @@ RUN corepack enable
 
 {{ .InstallCmd }}
 
-{{ if eq .ServiceDir "" }}COPY . .{{ end }}
+{{ if eq .AppDir "" }}COPY . .{{ end }}
 {{ if and (eq .Framework "nuxt.js") .Serverless }}
 ENV NITRO_PRESET=node
 {{ end }}
@@ -32,10 +32,10 @@ ENV NITRO_PRESET=node-server
 {{ if .BuildCmd }}RUN {{ .BuildCmd }}{{ end }}
 {{ if .Serverless }}
 FROM scratch as output
-COPY --from=build /src/{{ .ServiceDir }} /
+COPY --from=build /src/{{ .AppDir }} /
 {{ else if ne .OutputDir "" }}
 FROM scratch as output
-COPY --from=build /src/{{ .ServiceDir }}/{{ .OutputDir }} /
+COPY --from=build /src/{{ .AppDir }}/{{ .OutputDir }} /
 {{ else }}
 EXPOSE 8080
 CMD {{ .StartCmd }}{{ end }}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

This PR implements the discovery and building of Monorepo projects that are built with pnpm or Yarn workspaces.

Previously, we determined the application to build based solely on the root directory, which is usually the project repository. However, a repository may consist of multiple applications, and the old design did not work well in this situation.

Now, we introduce two new concepts: Project and Application. A "Project" typically refers to the entire repository, which contains common configuration like the package manager, linters, and zbpack.json. An "Application" is the application to deploy on Zeabur, which may be a subdirectory of a repository or the "Project" itself. It contains the dependencies of frameworks (like Next.js), the build commands, and the start commands.

Note that monorepos do not currently support caching (this feature has not been implemented yet). Nx monorepos are unsupported due to its complexity.

#### Related issues & labels (optional)

- Closes ZEA-3468, Fix #182<!-- Add an issue number if this PR will close it. -->
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
