### PR TITLE
ZEA-3493: PHP Planner supports npm build case

### DIFF
--- a/internal/php/identify.go
+++ b/internal/php/identify.go
@@ -34,7 +34,7 @@ func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
 	deps := DetermineAptDependencies(options.Source, server)
 	exts := DeterminePHPExtensions(options.Source)
 	app, property := DetermineApplication(options.Source)
-	buildCommand := DetermineBuildCommand(options.Config, options.CustomBuildCommand)
+	buildCommand := DetermineBuildCommand(options.Source, options.Config, options.CustomBuildCommand)
 	startCommand := DetermineStartCommand(options.Config, options.CustomStartCommand)
 
 	// Some meta will be added to the plan dynamically later.

--- a/internal/php/plan.go
+++ b/internal/php/plan.go
@@ -1,6 +1,7 @@
 package php
 
 import (
+	"bytes"
 	"fmt"
 	"slices"
 	"strings"
@@ -100,6 +101,11 @@ func DetermineAptDependencies(source afero.Fs, server string) []string {
 	// TODO: support RoadRunner
 	if server != "swoole" {
 		dependencies = append(dependencies, "nginx")
+	}
+
+	// Install Node.js if package.json exists.
+	if exists, _ := afero.Exists(source, "package.json"); exists {
+		dependencies = append(dependencies, "nodejs", "npm")
 	}
 
 	composerJSON, err := parseComposerJSON(source)

--- a/internal/php/plan.go
+++ b/internal/php/plan.go
@@ -188,12 +188,18 @@ func DetermineStartCommand(config plan.ImmutableProjectConfiguration, startComma
 }
 
 // DetermineBuildCommand determines the build command of the project.
-func DetermineBuildCommand(config plan.ImmutableProjectConfiguration, buildCommand *string) string {
+func DetermineBuildCommand(source afero.Fs, config plan.ImmutableProjectConfiguration, buildCommand *string) string {
 	if buildCommand != nil {
 		return *buildCommand
 	}
 	if buildCommand, err := plan.Cast(config.Get(plan.ConfigBuildCommand), cast.ToStringE).Take(); err == nil {
 		return buildCommand
+	}
+	if content, err := afero.ReadFile(source, "package.json"); err == nil {
+		if bytes.Contains(content, []byte("\"build\":")) {
+			// "build": "vite build"
+			return "npm install && npm run build"
+		}
 	}
 
 	return ""

--- a/internal/php/plan_apt_test.go
+++ b/internal/php/plan_apt_test.go
@@ -102,3 +102,12 @@ func TestDetermineAptDependencies_Unknown(t *testing.T) {
 	deps := DetermineAptDependencies(fs, "unknown")
 	assert.Equal(t, baseDepsWithNginx, deps)
 }
+
+func TestDetermineAptDependencies_NodeNpm(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "package.json", []byte(`{}`), 0644)
+
+	deps := DetermineAptDependencies(fs, "unknown")
+	assert.Contains(t, deps, "nodejs")
+	assert.Contains(t, deps, "npm")
+}

--- a/internal/php/plan_test.go
+++ b/internal/php/plan_test.go
@@ -138,7 +138,7 @@ func TestDetermineStartCommand_Default(t *testing.T) {
 	config := plan.NewProjectConfigurationFromFs(afero.NewMemMapFs(), "")
 	command := php.DetermineStartCommand(config, nil)
 
-	assert.Equal(t, "nginx; php-fpm", command)
+	assert.Contains(t, command, "nginx; php-fpm")
 }
 
 func TestDetermineStartCommand_Swoole(t *testing.T) {
@@ -146,7 +146,7 @@ func TestDetermineStartCommand_Swoole(t *testing.T) {
 	config.Set(php.ConfigLaravelOctaneServer, php.OctaneServerSwoole)
 	command := php.DetermineStartCommand(config, nil)
 
-	assert.Equal(t, "php artisan octane:start --server=swoole --host=0.0.0.0 --port=8080", command)
+	assert.Contains(t, command, "php artisan octane:start --server=swoole --host=0.0.0.0 --port=8080")
 }
 
 func TestDetermineStartCommand_Roadrunner(t *testing.T) {
@@ -156,7 +156,7 @@ func TestDetermineStartCommand_Roadrunner(t *testing.T) {
 	config.Set(php.ConfigLaravelOctaneServer, php.OctaneServerRoadrunner)
 	command := php.DetermineStartCommand(config, nil)
 
-	assert.Equal(t, "nginx; php-fpm", command)
+	assert.Contains(t, command, "nginx; php-fpm")
 }
 
 func TestDetermineStartCommand_UnknownOctane(t *testing.T) {
@@ -164,27 +164,27 @@ func TestDetermineStartCommand_UnknownOctane(t *testing.T) {
 	config.Set(php.ConfigLaravelOctaneServer, "unknown")
 	command := php.DetermineStartCommand(config, nil)
 
-	assert.Equal(t, "nginx; php-fpm", command)
+	assert.Contains(t, command, "nginx; php-fpm")
 }
 
 func TestDetermineStartCommand_CustomInConfig(t *testing.T) {
-	const expectedCommand = "php artisan serve"
+	const expectedCommand = "php artisan serve; _startup"
 
 	config := plan.NewProjectConfigurationFromFs(afero.NewMemMapFs(), "")
 	config.Set(plan.ConfigStartCommand, expectedCommand)
 
 	actualCommand := php.DetermineStartCommand(config, nil)
 
-	assert.Equal(t, expectedCommand, actualCommand)
+	assert.Contains(t, actualCommand, expectedCommand)
 }
 
 func TestDetermineStartCommand_CustomInOptions(t *testing.T) {
-	const expectedCommand = "php artisan serve"
+	const expectedCommand = "php artisan serve; _startup"
 
 	config := plan.NewProjectConfigurationFromFs(afero.NewMemMapFs(), "")
 	actualCommand := php.DetermineStartCommand(config, lo.ToPtr(expectedCommand))
 
-	assert.Equal(t, expectedCommand, actualCommand)
+	assert.Contains(t, actualCommand, expectedCommand)
 }
 
 func TestDetermineBuildCommand_Default(t *testing.T) {


### PR DESCRIPTION

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- **feat(planner/php): Install Node.js if `package.json` exists**
- **feat(planner/php): Run npm run build if there is "build" script**
- **fix(planner/php): Make default start command a function**
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-3493<!-- Add an issue number if this PR will close it. -->
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
