### PR TITLE
ZEA-3466: Python planner supports npm build case

### DIFF
--- a/internal/python/__snapshots__/plan_test.snap
+++ b/internal/python/__snapshots__/plan_test.snap
@@ -236,65 +236,65 @@ RUN pip install gunicorn
 ---
 
 [TestDetermineStartCmd_Snapshot/pip-none - 1]
-python app.py
+_startup() { python app.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/pip-with-fastapi - 1]
-uvicorn wsgi.py --host 0.0.0.0 --port 8080
+_startup() { uvicorn wsgi.py --host 0.0.0.0 --port 8080; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/pip-with-static - 1]
-/usr/sbin/nginx && gunicorn --bind :8000 wsgi.py
+_startup() { /usr/sbin/nginx && gunicorn --bind :8000 wsgi.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/pip-with-wsgi - 1]
-gunicorn --bind :8080 wsgi.py
+_startup() { gunicorn --bind :8080 wsgi.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/pipenv-none - 1]
-pipenv run python app.py
+_startup() { pipenv run python app.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/pipenv-with-fastapi - 1]
-pipenv run uvicorn wsgi.py --host 0.0.0.0 --port 8080
+_startup() { pipenv run uvicorn wsgi.py --host 0.0.0.0 --port 8080; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/pipenv-with-static - 1]
-/usr/sbin/nginx && pipenv run gunicorn --bind :8000 wsgi.py
+_startup() { /usr/sbin/nginx && pipenv run gunicorn --bind :8000 wsgi.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/pipenv-with-wsgi - 1]
-pipenv run gunicorn --bind :8080 wsgi.py
+_startup() { pipenv run gunicorn --bind :8080 wsgi.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/poetry-none - 1]
-poetry run python app.py
+_startup() { poetry run python app.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/poetry-with-fastapi - 1]
-poetry run uvicorn wsgi.py --host 0.0.0.0 --port 8080
+_startup() { poetry run uvicorn wsgi.py --host 0.0.0.0 --port 8080; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/poetry-with-static - 1]
-/usr/sbin/nginx && poetry run gunicorn --bind :8000 wsgi.py
+_startup() { /usr/sbin/nginx && poetry run gunicorn --bind :8000 wsgi.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/poetry-with-wsgi - 1]
-poetry run gunicorn --bind :8080 wsgi.py
+_startup() { poetry run gunicorn --bind :8080 wsgi.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/unknown-none - 1]
-python app.py
+_startup() { python app.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/unknown-with-fastapi - 1]
-uvicorn wsgi.py --host 0.0.0.0 --port 8080
+_startup() { uvicorn wsgi.py --host 0.0.0.0 --port 8080; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/unknown-with-static - 1]
-/usr/sbin/nginx && gunicorn --bind :8000 wsgi.py
+_startup() { /usr/sbin/nginx && gunicorn --bind :8000 wsgi.py; }; _startup
 ---
 
 [TestDetermineStartCmd_Snapshot/unknown-with-wsgi - 1]
-gunicorn --bind :8080 wsgi.py
+_startup() { gunicorn --bind :8080 wsgi.py; }; _startup
 ---

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -729,8 +729,8 @@ RUN reflex export --frontend-only --no-zip && mv .web/_static/* /srv/ && rm -rf 
 
 		if content, err := utils.ReadFileToUTF8(ctx.Src, "package.json"); err == nil {
 			if strings.Contains(string(content), "\"build\":") {
-				// for example, "build": "npm run build"
-				commands += "RUN npm install\n"
+				// for example, "build": "vite build"
+				commands += "RUN npm install && npm run build\n"
 			}
 		}
 	}

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -709,6 +709,13 @@ func determineBuildCmd(ctx *pythonPlanContext) string {
 	if buildCommand, err := plan.Cast(ctx.Config.Get(plan.ConfigBuildCommand), cast.ToStringE).Take(); err == nil {
 		commands += "RUN " + buildCommand + "\n"
 	} else {
+		if content, err := utils.ReadFileToUTF8(ctx.Src, "package.json"); err == nil {
+			if strings.Contains(string(content), "\"build\":") {
+				// for example, "build": "vite build"
+				commands += "RUN npm install && npm run build\n"
+			}
+		}
+
 		if framework == types.PythonFrameworkReflex {
 			commands += `RUN reflex init
 RUN reflex export --frontend-only --no-zip && mv .web/_static/* /srv/ && rm -rf .web`
@@ -725,13 +732,6 @@ RUN reflex export --frontend-only --no-zip && mv .web/_static/* /srv/ && rm -rf 
 
 		if determinePlaywright(ctx) {
 			commands += "RUN playwright install\n"
-		}
-
-		if content, err := utils.ReadFileToUTF8(ctx.Src, "package.json"); err == nil {
-			if strings.Contains(string(content), "\"build\":") {
-				// for example, "build": "vite build"
-				commands += "RUN npm install && npm run build\n"
-			}
 		}
 	}
 

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -529,6 +529,10 @@ func determineAptDependencies(ctx *pythonPlanContext) []string {
 		)
 	}
 
+	if ok, _ := afero.Exists(ctx.Src, "package.json"); ok {
+		deps = append(deps, "nodejs", "npm")
+	}
+
 	return deps
 }
 
@@ -718,6 +722,13 @@ RUN reflex export --frontend-only --no-zip && mv .web/_static/* /srv/ && rm -rf 
 
 	if determinePlaywright(ctx) {
 		commands += "RUN playwright install\n"
+	}
+
+	if content, err := utils.ReadFileToUTF8(ctx.Src, "package.json"); err == nil {
+		if strings.Contains(string(content), "\"build\":") {
+			// for example, "build": "npm run build"
+			commands += "RUN npm install\n"
+		}
 	}
 
 	return strings.TrimSpace(commands)

--- a/internal/python/plan_test.go
+++ b/internal/python/plan_test.go
@@ -1027,3 +1027,46 @@ func TestDeterminePythonVersion_Customized(t *testing.T) {
 
 	assert.Equal(t, "3.12345", determinePythonVersion(ctx))
 }
+
+func TestDetermineAptDependencies_Nodejs(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "package.json", []byte("{}"), 0o644)
+
+	ctx := &pythonPlanContext{
+		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
+		PackageManager: optional.Some(types.PythonPackageManagerUnknown),
+	}
+
+	assert.Contains(t, determineAptDependencies(ctx), "nodejs")
+	assert.Contains(t, determineAptDependencies(ctx), "npm")
+}
+
+func TestDetermineBuildCommand_NPMBuild(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "package.json", []byte(`{"scripts": {"build": "echo 'hi'"}}`), 0o644)
+
+	ctx := &pythonPlanContext{
+		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
+		PackageManager: optional.Some(types.PythonPackageManagerUnknown),
+	}
+
+	assert.Contains(t, determineBuildCmd(ctx), "npm install && npm run build")
+}
+
+func TestDetermineBuildCommand_Custom(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "package.json", []byte(`{"scripts": {"build": "echo 'hi'"}}`), 0o644)
+
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+	config.Set(plan.ConfigBuildCommand, "echo 'hello'")
+
+	ctx := &pythonPlanContext{
+		Src:            fs,
+		Config:         config,
+		PackageManager: optional.Some(types.PythonPackageManagerUnknown),
+	}
+
+	assert.Contains(t, determineBuildCmd(ctx), "echo 'hello'")
+}

--- a/internal/python/plan_test.go
+++ b/internal/python/plan_test.go
@@ -1070,3 +1070,19 @@ func TestDetermineBuildCommand_Custom(t *testing.T) {
 
 	assert.Contains(t, determineBuildCmd(ctx), "echo 'hello'")
 }
+
+func TestDetermineStartCommand_Custom(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+	config.Set(plan.ConfigStartCommand, "echo 'hello'")
+
+	ctx := &pythonPlanContext{
+		Src:            fs,
+		Config:         config,
+		PackageManager: optional.Some(types.PythonPackageManagerUnknown),
+	}
+
+	assert.Contains(t, determineStartCmd(ctx), "echo 'hello'")
+	assert.Contains(t, determineStartCmd(ctx), "_startup()") // should have the default startup function
+}


### PR DESCRIPTION
#### Description (required)

- **feat(planner/python): Implement npm toolchain and npm build support**
- **feat(planner/python): Allow customizing build command**

#### Example Repository

https://github.com/dali1756/5xcamp without `static` (artifacts) and `staticfiles` (Django collectstatic):

![CleanShot 2024-07-03 at 15 49 56@2x](https://github.com/zeabur/zbpack/assets/28441561/85c18aea-4ff1-4630-bb4a-fda58fd8f7c8)


`ZBPACK_BUILD_COMMAND` which customizes build command:

![CleanShot 2024-07-03 at 15 49 35@2x](https://github.com/zeabur/zbpack/assets/28441561/61f4ef14-1387-4a84-87e5-61ae7e3e8066)


`ZBPACK_START_COMMAND` which allows calling the default start command and our customized command:

![CleanShot 2024-07-03 at 15 48 40@2x](https://github.com/zeabur/zbpack/assets/28441561/74d1274b-aad0-4cf8-918e-d6afd9e467fd)

#### Related issues & labels (optional)

- Closes ZEA-3466<!-- Add an issue number if this PR will close it. -->
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
