### PR TITLE
ZEA-3543: Add Git Reference support for GithubFS (and CLI support)

### DIFF
--- a/internal/source/githubfs_black_test.go
+++ b/internal/source/githubfs_black_test.go
@@ -73,3 +73,29 @@ func TestGitHubFsOpenFile_WithWriteFlag(t *testing.T) {
 	_, err := fs.OpenFile("readme.md", os.O_RDWR, 0)
 	assert.ErrorIs(t, err, source.ErrReadonly)
 }
+
+func TestGitHubFsOpenFile_Ref(t *testing.T) {
+	token := getGithubToken(t)
+
+	fs := source.NewGitHubFs("zeabur", "zbpack", token, source.GitHubRef("9da82d05f3123cdb76b25d36c40cd12581e4eb82"))
+	f, err := fs.OpenFile("go.mod", os.O_RDONLY, 0)
+	if err != nil {
+		if strings.Contains(err.Error(), "401 Bad credentials") {
+			t.Skip("Skip due to 401 error.")
+			return
+		}
+
+		t.Fatal("error when opening file:", err)
+	}
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("error when reading file: %v", err)
+	}
+
+	if !strings.Contains(string(content), "go 1.19") {
+		t.Fatalf("unexpected content: %s", string(content))
+	}
+
+	t.Log(content)
+}

--- a/internal/zbpack/helper.go
+++ b/internal/zbpack/helper.go
@@ -50,6 +50,9 @@ func GetSubmoduleName(path string) (submoduleName string, err error) {
 	}
 
 	submoduleName = filepath.Base(absPath)
+	if prefix, _, ok := strings.Cut(submoduleName, "#"); ok {
+		return prefix, nil
+	}
 
 	return submoduleName, err
 }

--- a/pkg/zeaburpack/utils.go
+++ b/pkg/zeaburpack/utils.go
@@ -75,8 +75,11 @@ func getGitHubSourceFromURL(url, token string) (afero.Fs, error) {
 	repoOwner := parts[3]
 	repoName := parts[4]
 
-	src := source.NewGitHubFs(repoOwner, repoName, token)
-	return src, nil
+	if repoName, ref, ok := strings.Cut(repoName, "#"); ok && ref != "" {
+		return source.NewGitHubFs(repoOwner, repoName, token, source.GitHubRef(ref)), nil
+	}
+
+	return source.NewGitHubFs(repoOwner, repoName, token), nil
 }
 
 func getS3SourceFromURL(url string, cfg *aws.Config) afero.Fs {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- **feat(source): Allow specifying reference in GitHubFS** (`source.GitHubRef()`)
- **feat(lib): Allow specifying reference in URL** (format: `https://github.com/owner/repo#ref`)
- **feat(cli): Handle github ref case** (`repo#ref`'s submodule name is `repo`)
<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-3543
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
