### PR TITLE
ZEA-3556: Disable serverless for Monorepo

### DIFF
--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -852,6 +852,13 @@ func getServerless(ctx *nodePlanContext) bool {
 		return sl.Unwrap()
 	}
 
+	// For monorepo projects, we should not deploy as serverless
+	// until ZEA-3469 is resolved.
+	if GetMonorepoAppRoot(ctx) != "" {
+		*sl = optional.Some(false)
+		return sl.Unwrap()
+	}
+
 	framework := DetermineAppFramework(ctx)
 
 	defaultServerless := map[types.NodeProjectFramework]bool{

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -841,14 +841,15 @@ func GetStaticOutputDir(ctx *nodePlanContext) string {
 }
 
 func getServerless(ctx *nodePlanContext) bool {
-	if value, err := utils.GetExplicitServerlessConfig(ctx.Config).Take(); err == nil {
-		return value
-	}
-
 	sl := &ctx.Serverless
 
 	if serverless, err := sl.Take(); err == nil {
 		return serverless
+	}
+
+	if value, err := utils.GetExplicitServerlessConfig(ctx.Config).Take(); err == nil {
+		*sl = optional.Some(value)
+		return sl.Unwrap()
 	}
 
 	framework := DetermineAppFramework(ctx)

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -614,6 +614,11 @@ func GetMonorepoAppRoot(ctx *nodePlanContext) string {
 	if userAppDir, err := plan.Cast(
 		ctx.Config.Get(ConfigAppDir), cast.ToStringE,
 	).Take(); err == nil && userAppDir != "" {
+		if userAppDir == "/" {
+			ctx.AppDir = optional.Some("")
+			return ctx.AppDir.Unwrap()
+		}
+
 		ctx.AppDir = optional.Some(userAppDir)
 		return ctx.AppDir.Unwrap()
 	}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- **refactor(planner/nodejs): Turn userAppDir "/" to ""**
- **fix(planner/nodejs): Save config entry to ctx.Serverless**
- **feat(planner/nodejs): Disable serverless if app root is empty**
<!-- Please describe the change you are proposing, and why -->

#### Tests

**No serverless enabled in Next.js monorepo**

```
(devenv) bash-5.2$ zbpack -i .
2024/07/09 11:50:11 using submoduleName: turborepo-basic
2024/07/09 11:50:11 
╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ nodejs                                             ║
║───────────────────────────────────────────────────────────────────────║
║ packageManager   │ pnpm                                               ║
║───────────────────────────────────────────────────────────────────────║
║ framework        │ next.js                                            ║
║───────────────────────────────────────────────────────────────────────║
║ nodeVersion      │ 18                                                 ║
║───────────────────────────────────────────────────────────────────────║
║ installCmd       │ COPY . .                                           ║
║                  │ WORKDIR /src/apps/docs                             ║
║                  │ RUN pnpm install                                   ║
║───────────────────────────────────────────────────────────────────────║
║ buildCmd         │ pnpm run build                                     ║
║───────────────────────────────────────────────────────────────────────║
║ startCmd         │ pnpm start                                         ║
║───────────────────────────────────────────────────────────────────────║
║ appDir           │ apps/docs                                          ║
╚═══════════════════════════════════════════════════════════════════════╝
```

**`ZBPACK_APP_DIR=/` transforms to empty string**

```
(devenv) bash-5.2$ ZBPACK_APP_DIR="/" zbpack -i .
2024/07/09 11:50:10 using submoduleName: turborepo-basic
2024/07/09 11:50:10 Detected Monorepo. Disabling dependency caching.
2024/07/09 11:50:10 
╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ nodejs                                             ║
║───────────────────────────────────────────────────────────────────────║
║ startCmd         │ node index.js                                      ║
║───────────────────────────────────────────────────────────────────────║
║ packageManager   │ pnpm                                               ║
║───────────────────────────────────────────────────────────────────────║
║ framework        │ none                                               ║
║───────────────────────────────────────────────────────────────────────║
║ nodeVersion      │ 18                                                 ║
║───────────────────────────────────────────────────────────────────────║
║ installCmd       │ COPY . .                                           ║
║                  │ RUN pnpm install                                   ║
║───────────────────────────────────────────────────────────────────────║
║ buildCmd         │ pnpm run build                                     ║
╚═══════════════════════════════════════════════════════════════════════╝
```

#### Related issues & labels (optional)

- Closes ZEA-3556<!-- Add an issue number if this PR will close it. -->
- Suggested label: enhancement<!-- Help us triage by suggesting one of our labels that describes your PR -->
