### PR TITLE
ZEA-3456: Reimplement rust planner

### DIFF
--- a/internal/rust/plan.go
+++ b/internal/rust/plan.go
@@ -80,7 +80,21 @@ func getAppDir(ctx *rustPlanContext) string {
 // getAssets gets the assets list that needs to copy from project directory.
 func getAssets(ctx *rustPlanContext) []string {
 	assets := plan.Cast(ctx.Config.Get(ConfigRustAssets), cast.ToStringSliceE).TakeOr([]string{})
-	return assets
+	if len(assets) != 0 {
+		return assets
+	}
+
+	// Legacy configuration.
+	zeaburPreserve, err := afero.ReadFile(ctx.Src, ".zeabur-preserve")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Println(err)
+		}
+
+		return assets
+	}
+
+	return strings.FieldsFunc(string(zeaburPreserve), func(r rune) bool { return r == '\n' })
 }
 
 // needOpenssl checks if the project needs openssl.

--- a/internal/rust/plan.go
+++ b/internal/rust/plan.go
@@ -3,27 +3,42 @@ package rust
 import (
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
-	"github.com/moznion/go-optional"
 	"github.com/spf13/afero"
+	"github.com/spf13/cast"
 	"github.com/zeabur/zbpack/internal/utils"
 	"github.com/zeabur/zbpack/pkg/plan"
 	"github.com/zeabur/zbpack/pkg/types"
 )
 
-type rustPlanContext struct {
-	Src    afero.Fs
-	Config plan.ImmutableProjectConfiguration
+// ConfigRustEntry is the key for the binary entry name of the application.
+//
+// If this key is not set, the default value is the binary with the submodule name.
+// If there is no such submodule, it picks the first binary it found.
+const ConfigRustEntry = "rust.entry"
 
+// ConfigRustAppDir is the key for the directory of the application.
+//
+// If this key is not set, the default value is the current directory – "/".
+const ConfigRustAppDir = "rust.app_dir"
+
+// ConfigRustAssets is the key for the assets of the application.
+// It is an array.
+//
+// The assets will be copied to the root of the application.
+const ConfigRustAssets = "rust.assets"
+
+type rustPlanContext struct {
+	Src           afero.Fs
+	Config        plan.ImmutableProjectConfiguration
 	SubmoduleName string
-	Serverless    optional.Option[bool]
 }
 
 // GetMetaOptions is the options for GetMeta.
 type GetMetaOptions struct {
-	Src afero.Fs
-
+	Src    afero.Fs
 	Config plan.ImmutableProjectConfiguration
 	// In Rust, the submodule name is the binary name.
 	SubmoduleName string
@@ -32,6 +47,40 @@ type GetMetaOptions struct {
 // getServerless gets the serverless flag from the configuration.
 func getServerless(ctx *rustPlanContext) bool {
 	return utils.GetExplicitServerlessConfig(ctx.Config).TakeOr(false)
+}
+
+// getEntry gets the entry name from the configuration.
+func getEntry(ctx *rustPlanContext) string {
+	if entry, err := plan.Cast(ctx.Config.Get(ConfigRustEntry), cast.ToStringE).Take(); err == nil {
+		return entry
+	}
+
+	if ctx.SubmoduleName != "" {
+		return ctx.SubmoduleName
+	}
+
+	// If there is no entry named 'main', we find
+	// the first binary in the artifact directory.
+	return "main"
+}
+
+// getAppDir gets the application directory from the configuration.
+func getAppDir(ctx *rustPlanContext) string {
+	if appDir, err := plan.Cast(ctx.Config.Get(ConfigRustAppDir), cast.ToStringE).Take(); err == nil {
+		if appDir == "/" {
+			return "."
+		}
+
+		return appDir
+	}
+
+	return "." // current directory relative to root.
+}
+
+// getAssets gets the assets list that needs to copy from project directory.
+func getAssets(ctx *rustPlanContext) []string {
+	assets := plan.Cast(ctx.Config.Get(ConfigRustAssets), cast.ToStringSliceE).TakeOr([]string{})
+	return assets
 }
 
 // needOpenssl checks if the project needs openssl.
@@ -60,22 +109,14 @@ func GetMeta(options GetMetaOptions) types.PlanMeta {
 		Config:        options.Config,
 	}
 
-	var opensslFlag string
-	if needOpenssl(ctx.Src) {
-		opensslFlag = "yes"
-	} else {
-		opensslFlag = "no"
+	meta := types.PlanMeta{
+		"openssl":    strconv.FormatBool(needOpenssl(ctx.Src)),
+		"serverless": strconv.FormatBool(getServerless(ctx)),
+		"entry":      getEntry(ctx),
+		"appDir":     getAppDir(ctx),
+		// assets/1:assets/2:...
+		"assets": strings.Join(getAssets(ctx), ":"),
 	}
-
-	meta := types.PlanMeta{}
-
-	serverless := getServerless(ctx)
-	if serverless {
-		meta["serverless"] = "true"
-	}
-
-	meta["BinName"] = ctx.SubmoduleName
-	meta["NeedOpenssl"] = opensslFlag
 
 	return meta
 }

--- a/internal/rust/rust_test.go
+++ b/internal/rust/rust_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/zbpack/pkg/plan"
 )
 
 func TestNeedOpenssl_CargoLockfile(t *testing.T) {
@@ -26,4 +27,129 @@ func TestNeedOpenssl_None(t *testing.T) {
 	_ = afero.WriteFile(fs, "Cargo.toml", []byte(""), 0o644)
 
 	assert.False(t, needOpenssl(fs))
+}
+
+func TestGetEntry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no submodule name", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "")
+
+		entry := getEntry(&rustPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "",
+		})
+		assert.Equal(t, "main", entry)
+	})
+
+	t.Run("with submodule name", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "submodule")
+
+		entry := getEntry(&rustPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "submodule",
+		})
+		assert.Equal(t, "submodule", entry)
+	})
+
+	t.Run("configured", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "")
+		config.Set(ConfigRustEntry, "configured")
+
+		entry := getEntry(&rustPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "",
+		})
+		assert.Equal(t, "configured", entry)
+	})
+}
+
+func TestGetAppDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("configured", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "")
+		config.Set(ConfigRustAppDir, "configured")
+
+		appDir := getAppDir(&rustPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "",
+		})
+		assert.Equal(t, "configured", appDir)
+	})
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "")
+
+		appDir := getAppDir(&rustPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "",
+		})
+		assert.Equal(t, "", appDir)
+	})
+
+	t.Run("set as '/'", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "")
+		config.Set(ConfigRustAppDir, "/")
+
+		appDir := getAppDir(&rustPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "",
+		})
+		assert.Equal(t, "", appDir)
+	})
+}
+
+func TestGetAssets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pass as array (json)", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "")
+		config.Set(ConfigRustAssets, []string{"a", "b"})
+
+		assets := getAssets(&rustPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "",
+		})
+		assert.Equal(t, []string{"a", "b"}, assets)
+	})
+
+	t.Run("pass as string", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "")
+		config.Set(ConfigRustAssets, "a b c")
+
+		assets := getAssets(&rustPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "",
+		})
+		assert.Equal(t, []string{"a", "b", "c"}, assets)
+	})
 }

--- a/internal/rust/rust_test.go
+++ b/internal/rust/rust_test.go
@@ -105,7 +105,7 @@ func TestGetAppDir(t *testing.T) {
 			Config:        config,
 			SubmoduleName: "",
 		})
-		assert.Equal(t, "", appDir)
+		assert.Equal(t, ".", appDir)
 	})
 
 	t.Run("set as '/'", func(t *testing.T) {
@@ -120,7 +120,7 @@ func TestGetAppDir(t *testing.T) {
 			Config:        config,
 			SubmoduleName: "",
 		})
-		assert.Equal(t, "", appDir)
+		assert.Equal(t, ".", appDir)
 	})
 }
 
@@ -151,5 +151,28 @@ func TestGetAssets(t *testing.T) {
 			SubmoduleName: "",
 		})
 		assert.Equal(t, []string{"a", "b", "c"}, assets)
+	})
+
+	t.Run(".zeabur-preserve", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		_ = afero.WriteFile(fs, ".zeabur-preserve", []byte("a\nb\nc"), 0o644)
+
+		assets := getAssets(&rustPlanContext{
+			Src:           fs,
+			Config:        plan.NewProjectConfigurationFromFs(fs, ""),
+			SubmoduleName: "",
+		})
+		assert.Equal(t, []string{"a", "b", "c"}, assets)
+	})
+
+	t.Run("no assets", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+
+		assets := getAssets(&rustPlanContext{
+			Src:           fs,
+			Config:        plan.NewProjectConfigurationFromFs(fs, ""),
+			SubmoduleName: "",
+		})
+		assert.Empty(t, assets)
 	})
 }

--- a/internal/rust/template.Dockerfile
+++ b/internal/rust/template.Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 
 # Rename the entry point to /app/main
 RUN if [ -x "{{ .Entry }}" ]; then \
-	mv "{{ .Entry }}" /app/main \
+	mv "{{ .Entry }}" /app/main; \
   else \
   	real_endpoint="$(find . -type f -executable -print | head -n 1)" \
 		&& mv "${real_endpoint}" /app/main; \
@@ -37,7 +37,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 {{ end }}
 
-COPY --from=post-builder /app .
+COPY --from=post-builder /app /app
 CMD ["/app/main"]
 
 {{ end }}

--- a/internal/rust/template_test.go
+++ b/internal/rust/template_test.go
@@ -113,7 +113,7 @@ func TestGenerateDockerfile_Serverless(t *testing.T) {
 		}
 
 		assert.Contains(t, dockerfile, "FROM rust:1-slim AS runtime")
-		assert.Contains(t, dockerfile, "COPY --from=post-builder /app .")
+		assert.Contains(t, dockerfile, "COPY --from=post-builder /app /app")
 		assert.Contains(t, dockerfile, `CMD ["/app/main"]`)
 	})
 }

--- a/internal/rust/template_test.go
+++ b/internal/rust/template_test.go
@@ -1,0 +1,185 @@
+package rust_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/zbpack/internal/rust"
+)
+
+func TestGenerateDockerfile_Assets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("one assets", func(t *testing.T) {
+		t.Parallel()
+
+		meta := map[string]string{
+			"openssl":    "true",
+			"serverless": "true",
+			"entry":      "entry",
+			"appDir":     "appDir",
+			"assets":     "assets",
+		}
+
+		dockerfile, err := rust.GenerateDockerfile(meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assert.Contains(t, dockerfile, "COPY --from=builder /app/assets /app/assets")
+	})
+
+	t.Run("multiple assets", func(t *testing.T) {
+		t.Parallel()
+
+		meta := map[string]string{
+			"openssl":    "true",
+			"serverless": "true",
+			"entry":      "entry",
+			"appDir":     "appDir",
+			"assets":     "assets1:assets2",
+		}
+
+		dockerfile, err := rust.GenerateDockerfile(meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assert.Contains(t, dockerfile, "COPY --from=builder /app/assets1 /app/assets1")
+		assert.Contains(t, dockerfile, "COPY --from=builder /app/assets2 /app/assets2")
+	})
+}
+
+func TestGenerateDockerfile_OpenSSL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("true", func(t *testing.T) {
+		t.Parallel()
+
+		meta := map[string]string{
+			"openssl":    "true",
+			"serverless": "false",
+			"entry":      "entry",
+			"appDir":     "appDir",
+			"assets":     "assets",
+		}
+
+		dockerfile, err := rust.GenerateDockerfile(meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assert.Contains(t, dockerfile, "apt-get install -y openssl")
+	})
+}
+
+func TestGenerateDockerfile_Serverless(t *testing.T) {
+	t.Parallel()
+
+	t.Run("true", func(t *testing.T) {
+		t.Parallel()
+
+		meta := map[string]string{
+			"openssl":    "false",
+			"serverless": "true",
+			"entry":      "entry",
+			"appDir":     "appDir",
+			"assets":     "assets",
+		}
+
+		dockerfile, err := rust.GenerateDockerfile(meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assert.Contains(t, dockerfile, "FROM scratch")
+		assert.Contains(t, dockerfile, "COPY --from=post-builder /app .")
+	})
+
+	t.Run("false", func(t *testing.T) {
+		t.Parallel()
+
+		meta := map[string]string{
+			"openssl":    "false",
+			"serverless": "false",
+			"entry":      "entry",
+			"appDir":     "appDir",
+			"assets":     "assets",
+		}
+
+		dockerfile, err := rust.GenerateDockerfile(meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assert.Contains(t, dockerfile, "FROM rust:1-slim AS runtime")
+		assert.Contains(t, dockerfile, "COPY --from=post-builder /app .")
+		assert.Contains(t, dockerfile, `CMD ["/app/main"]`)
+	})
+}
+
+func TestGenerateDockerfile_AppDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("configured", func(t *testing.T) {
+		t.Parallel()
+
+		meta := map[string]string{
+			"openssl":    "false",
+			"serverless": "false",
+			"entry":      "entry",
+			"appDir":     "configured",
+			"assets":     "assets",
+		}
+
+		dockerfile, err := rust.GenerateDockerfile(meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assert.Contains(t, dockerfile, `cargo install --path "configured" --root /out`)
+	})
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
+		meta := map[string]string{
+			"openssl":    "false",
+			"serverless": "false",
+			"entry":      "entry",
+			"appDir":     ".",
+			"assets":     "assets",
+		}
+
+		dockerfile, err := rust.GenerateDockerfile(meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assert.Contains(t, dockerfile, `cargo install --path "." --root /out`)
+	})
+}
+
+func TestGenerateDockerfile_Entry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("configured", func(t *testing.T) {
+		t.Parallel()
+
+		meta := map[string]string{
+			"openssl":    "false",
+			"serverless": "false",
+			"entry":      "configured",
+			"appDir":     ".",
+			"assets":     "assets",
+		}
+
+		dockerfile, err := rust.GenerateDockerfile(meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assert.Contains(t, dockerfile, `if [ -x "configured" ]; then`)
+		assert.Contains(t, dockerfile, `mv "configured" /app/main`)
+	})
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- **refactor(planner/rust): Rewrite Rust planner**
- **feat(planner/rust): Implement legacy zeabur-preserve**

Add configuration:

```go
// ConfigRustEntry is the key for the binary entry name of the application.
//
// If this key is not set, the default value is the binary with the submodule name.
// If there is no such submodule, it picks the first binary it found.
const ConfigRustEntry = "rust.entry"

// ConfigRustAppDir is the key for the directory of the application.
//
// If this key is not set, the default value is the current directory – "/".
const ConfigRustAppDir = "rust.app_dir"

// ConfigRustAssets is the key for the assets of the application.
// It is an array.
//
// The assets will be copied to the root of the application.
const ConfigRustAssets = "rust.assets"
```

#### Tests

https://github.com/UnblockNeteaseMusic/server-rust

```
$ ZBPACK_SERVERLESS=true ZBPACK_RUST_ASSETS="COPYING COPYING.LESSER" ZBPACK_RUST_APP_DIR="rest-api" BUILDKIT_HOST=docker-container://buildkitd zbpack .
2024/07/15 17:48:25 using submoduleName: unm-server-rust
2024/07/15 17:48:25
╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ rust                                               ║
║───────────────────────────────────────────────────────────────────────║
║ openssl          │ true                                               ║
║───────────────────────────────────────────────────────────────────────║
║ serverless       │ true                                               ║
║───────────────────────────────────────────────────────────────────────║
║ entry            │ unm-server-rust                                    ║
║───────────────────────────────────────────────────────────────────────║
║ appDir           │ rest-api                                           ║
║───────────────────────────────────────────────────────────────────────║
║ assets           │ COPYING:COPYING.LESSER                             ║
╚═══════════════════════════════════════════════════════════════════════╝
<omitted>

$ ls .zeabur/output/functions/__rs.func/
.zb-config.json  COPYING          COPYING.LESSER   main
```

https://github.com/pan93412/zeabur_axum_crash_test

```
$ BUILDKIT_HOST=docker-container://buildkitd zbpack .
2024/07/15 17:49:13 using submoduleName: zeabur_axum_crash_test
2024/07/15 17:49:13 environment variables to pass: map[]

╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ rust                                               ║
║───────────────────────────────────────────────────────────────────────║
║ openssl          │ true                                               ║
║───────────────────────────────────────────────────────────────────────║
║ entry            │ zeabur_axum_crash_test                             ║
║───────────────────────────────────────────────────────────────────────║
║ appDir           │ .                                                  ║
╚═══════════════════════════════════════════════════════════════════════╝

$ docker run -p 8080:8080 -e PORT=8080 -it zeabur-axum-crash-test
2024-07-15T09:49:39.695141Z  INFO zeabur_axum_crash_test: app is listing on 8080
```

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-3456
- Suggested label: bug<!-- Help us triage by suggesting one of our labels that describes your PR -->
