### PR TITLE
fix(lib): Support parsing of `--platform`

### DIFF
--- a/pkg/zeaburpack/parser.go
+++ b/pkg/zeaburpack/parser.go
@@ -6,7 +6,7 @@ import (
 	"github.com/samber/mo"
 )
 
-var fromStatementRegex = regexp.MustCompile(`(?i)^\s*FROM\s+(?P<src>\S*)(?:\s+AS\s+(?P<stage>\S+))?`)
+var fromStatementRegex = regexp.MustCompile(`(?i)^\s*FROM(?:\s+--platform=.+?)?\s+(?P<src>\S*)(?:\s+AS\s+(?P<stage>\S+))?`)
 
 // FromStatement represents a FROM statement in a Dockerfile.
 type FromStatement struct {

--- a/pkg/zeaburpack/parser_test.go
+++ b/pkg/zeaburpack/parser_test.go
@@ -56,6 +56,14 @@ func TestParseFrom(t *testing.T) {
 			Source: "alpine",
 			Stage:  mo.Some("builder"),
 		},
+		"FROM --platform=linux/amd64 alpine AS builder": {
+			Source: "alpine",
+			Stage:  mo.Some("builder"),
+		},
+		"FROM --platform=$BUILDERPLATFORM alpine:3.12 AS builder": {
+			Source: "alpine:3.12",
+			Stage:  mo.Some("builder"),
+		},
 	}
 
 	for k, v := range testmap {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Improve `fromStatementRegex` to cover `--platform=.+?`.

<!-- Please describe the change you are proposing, and why -->

#### Related issues & labels (optional)

- Closes ZEA-3642<!-- Add an issue number if this PR will close it. -->
- Suggested label: bug<!-- Help us triage by suggesting one of our labels that describes your PR -->
