### PR TITLE
fix(planner/rust): Set WORKDIR for more intuitive usage

### DIFF
--- a/internal/rust/template.Dockerfile
+++ b/internal/rust/template.Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
 {{ end }}
 
 COPY --from=post-builder /app /app
+WORKDIR /app
 CMD ["/app/main"]
 
 {{ end }}

--- a/internal/rust/template_test.go
+++ b/internal/rust/template_test.go
@@ -183,3 +183,22 @@ func TestGenerateDockerfile_Entry(t *testing.T) {
 		assert.Contains(t, dockerfile, `mv "configured" /app/main`)
 	})
 }
+
+func TestGenerateDockerfile_Workdir(t *testing.T) {
+	t.Parallel()
+
+	meta := map[string]string{
+		"openssl":    "false",
+		"serverless": "false",
+		"entry":      "entry",
+		"appDir":     ".",
+		"assets":     "assets",
+	}
+
+	dockerfile, err := rust.GenerateDockerfile(meta)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assert.Contains(t, dockerfile, `WORKDIR /app`)
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Currently, the working directory of a Rust application is `/`, which is not intuitive and stable. This PR changes the working directory to `/app`, where the application binary stored. *Breaking*.

#### Related issues & labels (optional)

- Closes ZEA-3682<!-- Add an issue number if this PR will close it. -->
- Suggested label: bug<!-- Help us triage by suggesting one of our labels that describes your PR -->
