### PR TITLE
feat(planner/gleam): Upgrade Gleam to v1.3.2

### DIFF
--- a/internal/gleam/gleam.go
+++ b/internal/gleam/gleam.go
@@ -8,7 +8,7 @@ import (
 
 // GenerateDockerfile generates the Dockerfile for Gleam projects.
 func GenerateDockerfile(_ types.PlanMeta) (string, error) {
-	return `FROM ghcr.io/gleam-lang/gleam:v1.0.0-erlang-alpine
+	return `FROM ghcr.io/gleam-lang/gleam:v1.3.2-erlang-alpine
 RUN apk add --no-cache elixir
 RUN mix local.hex --force
 RUN mix local.rebar --force


### PR DESCRIPTION
#### Description (required)

Upgrade Gleam to v1.3.2, which is [the latest version in the GitHub registry](https://github.com/gleam-lang/gleam/pkgs/container/gleam/versions?filters%5Bversion_type%5D=tagged).

#### Related issues & labels (optional)

- Closes #325
- Suggested label: enhancement
