### PR TITLE
feat(planner/nodejs): Determine Vitepress output directory from build script

### DIFF
--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -395,3 +395,45 @@ func TestInstallCommand(t *testing.T) {
 		assert.NotContains(t, installCmd, "WORKDIR")
 	})
 }
+
+func TestGetStaticOutputDir(t *testing.T) {
+	t.Run("vitepress, not specified docs directory", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		_ = afero.WriteFile(fs, "package.json", []byte(`{
+			"scripts": {
+				"build": "vitepress build"
+			},
+			"devDependencies": {
+				"vitepress": "*"
+			}
+		}`), 0o644)
+
+		ctx := &nodePlanContext{
+			Src:                fs,
+			Config:             plan.NewProjectConfigurationFromFs(fs, ""),
+			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
+		}
+
+		assert.Equal(t, ".vitepress/dist", GetStaticOutputDir(ctx))
+	})
+
+	t.Run("vitepress, specified docs directory", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		_ = afero.WriteFile(fs, "package.json", []byte(`{
+			"scripts": {
+				"build": "vitepress build docs"
+			},
+			"devDependencies": {
+				"vitepress": "*"
+			}
+		}`), 0o644)
+
+		ctx := &nodePlanContext{
+			Src:                fs,
+			Config:             plan.NewProjectConfigurationFromFs(fs, ""),
+			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
+		}
+
+		assert.Equal(t, "docs/.vitepress/dist", GetStaticOutputDir(ctx))
+	})
+}


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

Determine the output directory of Vitepress by the `build` script:

```json
{
  "scripts": {
    "build": "vitepress build docs"
  }
}
```

Here, the argument `docs` is the directory the docs is placed at.

#### Related issues & labels (optional)

- Closes ZEA-3712
- Suggested label: enhancement
