### PR TITLE
feat(planner/golang): Support build command and CGO

### DIFF
--- a/internal/golang/golang.go
+++ b/internal/golang/golang.go
@@ -8,13 +8,29 @@ import (
 
 // GenerateDockerfile generates the Dockerfile for Golang projects.
 func GenerateDockerfile(meta types.PlanMeta) (string, error) {
+	cgoEnvSegment := "ENV CGO_ENABLED=0\n"
+	if meta["cgo"] == "true" {
+		cgoEnvSegment = "ENV CGO_ENABLED=1\n"
+	}
+
+	dependencySegment := ""
+	if meta["cgo"] == "true" {
+		dependencySegment = "RUN apk add --no-cache build-base cmake\n"
+	}
+
+	buildCommandSegment := ""
+	if meta["buildCommand"] != "" {
+		buildCommandSegment = `RUN ` + meta["buildCommand"] + "\n"
+	}
+
 	buildStage := `FROM docker.io/library/golang:` + meta["goVersion"] + `-alpine as builder
 RUN mkdir /src
 WORKDIR /src
+` + dependencySegment + `
 COPY go.mod go.sum* ./
 RUN go mod download
 COPY . /src/
-ENV CGO_ENABLED=0
+` + cgoEnvSegment + buildCommandSegment + `
 RUN go build -o ./bin/server ` + meta["entry"]
 
 	runtimeStage := `FROM alpine as runtime

--- a/internal/golang/golang_test.go
+++ b/internal/golang/golang_test.go
@@ -1,0 +1,92 @@
+package golang_test
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zeabur/zbpack/internal/golang"
+	"github.com/zeabur/zbpack/pkg/types"
+)
+
+func TestGenerateDockerfile_CGO(t *testing.T) {
+	t.Parallel()
+
+	baseMeta := types.PlanMeta{
+		"goVersion": "1.22",
+		"entry":     "main.go",
+	}
+
+	t.Run("CGO enabled", func(t *testing.T) {
+		t.Parallel()
+
+		meta := maps.Clone(baseMeta)
+		meta["cgo"] = "true"
+
+		dockerfile, err := golang.GenerateDockerfile(meta)
+		require.NoError(t, err)
+
+		assert.Contains(t, dockerfile, "ENV CGO_ENABLED=1\n")
+		assert.Contains(t, dockerfile, "RUN apk add --no-cache build-base cmake\n")
+	})
+
+	t.Run("CGO disabled", func(t *testing.T) {
+		t.Parallel()
+
+		meta := maps.Clone(baseMeta)
+		meta["cgo"] = "false"
+
+		dockerfile, err := golang.GenerateDockerfile(meta)
+		require.NoError(t, err)
+
+		assert.Contains(t, dockerfile, "ENV CGO_ENABLED=0\n")
+		assert.NotContains(t, dockerfile, "RUN apk add --no-cache build-base cmake\n")
+	})
+}
+
+func TestGenerateDockerfile_BuildCommand(t *testing.T) {
+	t.Parallel()
+
+	baseMeta := types.PlanMeta{
+		"goVersion": "1.22",
+		"entry":     "main.go",
+	}
+
+	t.Run("with build command", func(t *testing.T) {
+		t.Parallel()
+
+		meta := maps.Clone(baseMeta)
+		meta["buildCommand"] = "go generate ./..."
+
+		dockerfile, err := golang.GenerateDockerfile(meta)
+		require.NoError(t, err)
+
+		assert.Contains(t, dockerfile, "RUN go generate ./...\n\nRUN go build -o ./bin/server")
+	})
+
+	t.Run("without build command", func(t *testing.T) {
+		t.Parallel()
+
+		meta := maps.Clone(baseMeta)
+
+		dockerfile, err := golang.GenerateDockerfile(meta)
+		require.NoError(t, err)
+
+		assert.NotContains(t, dockerfile, "RUN go generate ./...\n")
+		assert.Contains(t, dockerfile, "RUN go build -o ./bin/server")
+	})
+
+	t.Run("cgo + build command", func(t *testing.T) {
+		t.Parallel()
+
+		meta := maps.Clone(baseMeta)
+		meta["cgo"] = "true"
+		meta["buildCommand"] = "go generate ./..."
+
+		dockerfile, err := golang.GenerateDockerfile(meta)
+		require.NoError(t, err)
+
+		assert.Contains(t, dockerfile, "ENV CGO_ENABLED=1\nRUN go generate ./...\n\nRUN go build -o ./bin/server")
+	})
+}

--- a/internal/golang/plan_test.go
+++ b/internal/golang/plan_test.go
@@ -1,0 +1,90 @@
+package golang
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zeabur/zbpack/pkg/plan"
+)
+
+func TestGetBuildCommand(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without build command", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "test")
+
+		ctx := &goPlanContext{
+			Src:    fs,
+			Config: config,
+		}
+
+		buildCommand := getBuildCommand(ctx)
+		assert.Equal(t, "", buildCommand)
+	})
+
+	t.Run("with build command", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "test")
+		config.Set(plan.ConfigBuildCommand, "go generate ./...")
+
+		ctx := &goPlanContext{
+			Src:    fs,
+			Config: config,
+		}
+
+		buildCommand := getBuildCommand(ctx)
+		assert.Equal(t, "go generate ./...", buildCommand)
+	})
+}
+
+func TestIsCgoEnabled(t *testing.T) {
+	// Clear the user's environment variables.
+	require.NoError(t, os.Setenv("CGO_ENABLED", ""))
+
+	t.Run("default", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "test")
+
+		ctx := &goPlanContext{
+			Src:    fs,
+			Config: config,
+		}
+
+		assert.False(t, isCgoEnabled(ctx))
+	})
+
+	t.Run("with config", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "test")
+		config.Set(ConfigCgo, true)
+
+		ctx := &goPlanContext{
+			Src:    fs,
+			Config: config,
+		}
+
+		assert.True(t, isCgoEnabled(ctx))
+	})
+
+	t.Run("with env", func(t *testing.T) {
+		require.NoError(t, os.Setenv("CGO_ENABLED", "1"))
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "test")
+
+		ctx := &goPlanContext{
+			Src:    fs,
+			Config: config,
+		}
+
+		assert.True(t, isCgoEnabled(ctx))
+	})
+}


### PR DESCRIPTION
#### Description (required)

Allow specifying the build command and `ENABLE_CGO` flag, making Go planner more useful.

```
$ ZBPACK_BUILD_COMMAND="go generate ./..." ZBPACK_CGO=true BUILDKIT_HOST=docker-container://buildkitd zbpack . 
2024/07/30 12:42:34 using submoduleName: zbpack
2024/07/30 12:42:34 environment variables to pass: map[]

╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ go                                                 ║
║───────────────────────────────────────────────────────────────────────║
║ entry            │ cmd/zbpack/main.go                                 ║
║───────────────────────────────────────────────────────────────────────║
║ buildCommand     │ go generate ./...                                  ║
║───────────────────────────────────────────────────────────────────────║
║ cgo              │ true                                               ║
║───────────────────────────────────────────────────────────────────────║
║ goVersion        │ 1.21.0                                             ║
╚═══════════════════════════════════════════════════════════════════════╝

```

```
$ ZBPACK_BUILD_COMMAND="go generate ./..." CGO_ENABLED=1 BUILDKIT_HOST=docker-container://buildkitd zbpack .
2024/07/30 12:41:19 using submoduleName: zbpack
2024/07/30 12:41:19 environment variables to pass: map[]

╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ go                                                 ║
║───────────────────────────────────────────────────────────────────────║
║ goVersion        │ 1.21.0                                             ║
║───────────────────────────────────────────────────────────────────────║
║ entry            │ cmd/zbpack/main.go                                 ║
║───────────────────────────────────────────────────────────────────────║
║ buildCommand     │ go generate ./...                                  ║
║───────────────────────────────────────────────────────────────────────║
║ cgo              │ true                                               ║
╚═══════════════════════════════════════════════════════════════════════╝
```

#### Related issues & labels (optional)

- Closes ZEA-3721
- Suggested label: enhancement
