### PR TITLE
ZEA-3822: Implement planning of a plain Nitro application

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -2,8 +2,8 @@ schema = 3
 
 [mod]
   [mod."github.com/aws/aws-sdk-go"]
-    version = "v1.54.19"
-    hash = "sha256-LEAk2Tv8CqNrk9wnk0O62qU7CGQnjJD6QMutmJfWlPA="
+    version = "v1.55.5"
+    hash = "sha256-Duod/yk0bGmbcqgaZg+4XoWwY7Ysq4RA/cFBV8nFX6E="
   [mod."github.com/codeclysm/extract/v3"]
     version = "v3.1.1"
     hash = "sha256-m97BzuMk+rlSfPUnYzWifqQBNNdrWZXhUlQwT2iY59A="
@@ -35,11 +35,11 @@ schema = 3
     version = "v1.3.2"
     hash = "sha256-Qh2lAShlRm571xMxhAOfRoaFYzrfHmmk7RQmSiJxPbo="
   [mod."github.com/gkampitakis/go-snaps"]
-    version = "v0.5.4"
-    hash = "sha256-5q/Fvei+MVG3Sua1aIvD/zw6a6RUvZSDW2OV3NCp/m4="
+    version = "v0.5.7"
+    hash = "sha256-DCfko42wd7W9NadYPPX9c9H2HNH9DQHZTrfI9CTZqXQ="
   [mod."github.com/goccy/go-yaml"]
-    version = "v1.11.3"
-    hash = "sha256-bVhCMoAcBe+JTnul+oIVZKCYRduoImPitmkDGp4XY4c="
+    version = "v1.12.0"
+    hash = "sha256-0mCOEhUeOmQOU66adWwh+53SUSowpVrm8ILwLhVGc6g="
   [mod."github.com/google/go-github/v63"]
     version = "v63.0.0"
     hash = "sha256-Yl33aGOXdGthRVp8vrM3At1NqvI/J3/LE82boXJ/rQs="
@@ -122,11 +122,11 @@ schema = 3
     version = "v0.1.0"
     hash = "sha256-F92BQXXmn3mCwu3mBaGh+joTRItQDSDhsjU6SofkYdA="
   [mod."github.com/samber/lo"]
-    version = "v1.45.0"
-    hash = "sha256-heidXoRZUcnupitODFoSqyxYaw9C/FoOr5Yc6u9/nPA="
+    version = "v1.46.0"
+    hash = "sha256-ZvyiOnjqh3nt8OxofUPbXxN14j5bHcmT9TqOCPdwAVQ="
   [mod."github.com/samber/mo"]
-    version = "v1.12.0"
-    hash = "sha256-b01gDW5s6QXf8WU10UTZrsYx3U2DKPyBOT44uaXize4="
+    version = "v1.13.0"
+    hash = "sha256-mtMkttCJdlTc+gArMqWpkoO2V5Ef/OXuKk/dusez01g="
   [mod."github.com/sourcegraph/conc"]
     version = "v0.3.0"
     hash = "sha256-mIdMs9MLAOBKf3/0quf1iI3v8uNWydy7ae5MFa+F2Ko="

--- a/internal/bun/identify.go
+++ b/internal/bun/identify.go
@@ -31,9 +31,9 @@ func (i *identify) Match(fs afero.Fs) bool {
 		hasBunTypes = bytes.Contains(packageJSON, []byte(`"bun-types"`))
 	}
 
-	// Some developer use bun as package manager for their Next.js or Nuxt.js project.
+	// Some developer use bun as package manager for their Next.js project.
 	// In this case, we should treat it as a Node.js project.
-	if bytes.Contains(packageJSON, []byte(`"next"`)) || bytes.Contains(packageJSON, []byte(`"nuxt"`)) {
+	if bytes.Contains(packageJSON, []byte(`"next"`)) {
 		return false
 	}
 

--- a/internal/nodejs/__snapshots__/template_test.snap
+++ b/internal/nodejs/__snapshots__/template_test.snap
@@ -20,7 +20,6 @@ RUN bun install
 
 COPY . .
 
-
 # Build if we can build it
 
 
@@ -43,7 +42,6 @@ RUN corepack enable
 RUN yarn install
 
 COPY . .
-
 
 # Build if we can build it
 RUN yarn build
@@ -68,7 +66,6 @@ RUN corepack enable
 RUN yarn install
 
 COPY . .
-
 
 # Build if we can build it
 RUN yarn build
@@ -95,7 +92,6 @@ RUN yarn install
 
 
 
-
 # Build if we can build it
 
 
@@ -117,7 +113,6 @@ RUN corepack enable
 
 WORKDIR /src/myservice
 RUN yarn install
-
 
 
 
@@ -146,7 +141,6 @@ RUN yarn install
 
 
 
-
 # Build if we can build it
 
 
@@ -171,7 +165,6 @@ RUN yarn install
 
 COPY . .
 
-
 # Build if we can build it
 
 
@@ -195,7 +188,6 @@ RUN yarn install
 
 COPY . .
 
-
 # Build if we can build it
 
 
@@ -218,7 +210,6 @@ RUN corepack enable
 RUN yarn install
 
 COPY . .
-
 
 # Build if we can build it
 

--- a/internal/nodejs/node.go
+++ b/internal/nodejs/node.go
@@ -4,6 +4,7 @@ package nodejs
 import (
 	"bytes"
 	"embed"
+	"strings"
 	"text/template"
 
 	"github.com/zeabur/zbpack/pkg/packer"
@@ -32,6 +33,9 @@ var tmplFs embed.FS
 
 var tmpl = template.Must(
 	template.New("template.Dockerfile").
+		Funcs(template.FuncMap{
+			"prefixed": strings.HasPrefix,
+		}).
 		ParseFS(tmplFs, "templates/*"),
 )
 

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -749,7 +749,11 @@ func GetStartCmd(ctx *nodePlanContext) string {
 			startCmd = "node " + entry
 		case framework == types.NodeProjectFrameworkNuxtJs,
 			framework == types.NodeProjectFrameworkNitropack:
-			startCmd = "node .output/server/index.mjs"
+			if ctx.Bun {
+				startCmd = "bun .output/server/index.mjs"
+			} else {
+				startCmd = "node .output/server/index.mjs"
+			}
 		default:
 			startCmd = "node index.js"
 		}

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -439,9 +439,11 @@ func GetStartScript(ctx *nodePlanContext) string {
 	return ss.Unwrap()
 }
 
-const defaultNodeVersion = "18"
-const maxNodeVersion uint64 = 21
-const maxLtsNodeVersion uint64 = 18
+const (
+	defaultNodeVersion        = "18"
+	maxNodeVersion     uint64 = 21
+	maxLtsNodeVersion  uint64 = 18
+)
 
 func getNodeVersion(versionConstraint string) string {
 	// .nvmrc extensions
@@ -746,7 +748,11 @@ func GetStartCmd(ctx *nodePlanContext) string {
 	if startScript == "" {
 		switch {
 		case entry != "":
-			startCmd = "node " + entry
+			if ctx.Bun {
+				startCmd = "bun " + entry
+			} else {
+				startCmd = "node " + entry
+			}
 		case framework == types.NodeProjectFrameworkNuxtJs,
 			framework == types.NodeProjectFrameworkNitropack:
 			if ctx.Bun {
@@ -755,7 +761,11 @@ func GetStartCmd(ctx *nodePlanContext) string {
 				startCmd = "node .output/server/index.mjs"
 			}
 		default:
-			startCmd = "node index.js"
+			if ctx.Bun {
+				startCmd = "bun index.js"
+			} else {
+				startCmd = "node index.js"
+			}
 		}
 	}
 

--- a/internal/nodejs/templates/template.Dockerfile
+++ b/internal/nodejs/templates/template.Dockerfile
@@ -22,10 +22,10 @@ RUN corepack enable
 {{ .InstallCmd }}
 
 {{ if eq .AppDir "" }}COPY . .{{ end }}
-{{ if and (eq .Framework "nuxt.js") .Serverless }}
+{{ if and (or (eq .Framework "nuxt.js") (eq .Framework "nitropack")) .Serverless }}
 ENV NITRO_PRESET=node
 {{ end }}
-{{ if and (eq .Framework "nuxt.js") (not .Serverless) }}
+{{ if and (or (eq .Framework "nuxt.js") (eq .Framework "nitropack")) (not .Serverless) }}
 ENV NITRO_PRESET=node-server
 {{ end }}
 # Build if we can build it

--- a/internal/nodejs/templates/template.Dockerfile
+++ b/internal/nodejs/templates/template.Dockerfile
@@ -22,11 +22,14 @@ RUN corepack enable
 {{ .InstallCmd }}
 
 {{ if eq .AppDir "" }}COPY . .{{ end }}
-{{ if and (or (eq .Framework "nuxt.js") (eq .Framework "nitropack")) .Serverless }}
+{{ if or (eq .Framework "nuxt.js") (eq .Framework "nitropack") }}
+{{ if .Serverless }}
 ENV NITRO_PRESET=node
-{{ end }}
-{{ if and (or (eq .Framework "nuxt.js") (eq .Framework "nitropack")) (not .Serverless) }}
+{{ else if and (not .Serverless) (prefixed .StartCmd "bun") }}
+ENV NITRO_PRESET=bun
+{{ else }}
 ENV NITRO_PRESET=node-server
+{{ end }}
 {{ end }}
 # Build if we can build it
 {{ if .BuildCmd }}RUN {{ .BuildCmd }}{{ end }}

--- a/pkg/types/plan.go
+++ b/pkg/types/plan.go
@@ -86,6 +86,7 @@ const (
 	NodeProjectFrameworkVocs             NodeProjectFramework = "vocs"
 	NodeProjectFrameworkRspress          NodeProjectFramework = "rspress"
 	NodeProjectFrameworkGrammY           NodeProjectFramework = "grammy"
+	NodeProjectFrameworkNitropack        NodeProjectFramework = "nitropack"
 )
 
 //revive:enable:exported

--- a/pkg/zeaburpack/main.go
+++ b/pkg/zeaburpack/main.go
@@ -412,7 +412,7 @@ func Build(opt *BuildOptions) error {
 		}
 	}
 
-	if t == types.PlanTypeNodejs && m["framework"] == string(types.NodeProjectFrameworkNuxtJs) && m["serverless"] == "true" {
+	if (t == types.PlanTypeNodejs || t == types.PlanTypeBun) && (m["framework"] == string(types.NodeProjectFrameworkNuxtJs) || m["framework"] == string(types.NodeProjectFrameworkNitropack)) && m["serverless"] == "true" {
 		println("Transforming build output to serverless format ...")
 		err = nuxtjs.TransformServerless(*opt.Path)
 		if err != nil {


### PR DESCRIPTION
#### Description (required)

- Support [Nitropack](https://nitro.unjs.io).
- Allow running Nitro-based applications (Nuxt.js, Nitropack) as Bun server (if `SERVERLESS` is disabled).
- Allow building Nitropack as a serverless application.

#### Related issues & labels (optional)

- Closes ZEA-3822
- Suggested label: enhancement
