### PR TITLE
ZEA-3857: Support new Nitro-based SolidStart package

### DIFF
--- a/internal/nodejs/node.go
+++ b/internal/nodejs/node.go
@@ -35,6 +35,7 @@ var tmpl = template.Must(
 	template.New("template.Dockerfile").
 		Funcs(template.FuncMap{
 			"prefixed": strings.HasPrefix,
+			"isNitro":  types.IsNitroBasedFramework,
 		}).
 		ParseFS(tmplFs, "templates/*"),
 )

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -753,8 +753,7 @@ func GetStartCmd(ctx *nodePlanContext) string {
 			} else {
 				startCmd = "node " + entry
 			}
-		case framework == types.NodeProjectFrameworkNuxtJs,
-			framework == types.NodeProjectFrameworkNitropack:
+		case types.IsNitroBasedFramework(string(framework)):
 			if ctx.Bun {
 				startCmd = "bun .output/server/index.mjs"
 			} else {

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -209,8 +209,7 @@ func DetermineAppFramework(ctx *nodePlanContext) types.NodeProjectFramework {
 		return fw.Unwrap()
 	}
 	if _, isSolid := packageJSON.FindDependency("@solidjs/start"); isSolid {
-		// v1.0+. Nitro-based.
-		*fw = optional.Some(types.NodeProjectFrameworkSolidStartV1)
+		*fw = optional.Some(types.NodeProjectFrameworkSolidStartVinxi)
 		return fw.Unwrap()
 	}
 

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -208,6 +208,11 @@ func DetermineAppFramework(ctx *nodePlanContext) types.NodeProjectFramework {
 		*fw = optional.Some(types.NodeProjectFrameworkSolidStart)
 		return fw.Unwrap()
 	}
+	if _, isSolid := packageJSON.FindDependency("@solidjs/start"); isSolid {
+		// v1.0+. Nitro-based.
+		*fw = optional.Some(types.NodeProjectFrameworkSolidStartV1)
+		return fw.Unwrap()
+	}
 
 	if _, isSliDev := packageJSON.Dependencies["@slidev/cli"]; isSliDev {
 		*fw = optional.Some(types.NodeProjectFrameworkSliDev)

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -904,14 +904,15 @@ func getServerless(ctx *nodePlanContext) bool {
 	framework := DetermineAppFramework(ctx)
 
 	defaultServerless := map[types.NodeProjectFramework]bool{
-		types.NodeProjectFrameworkNextJs:    true,
-		types.NodeProjectFrameworkNuxtJs:    true,
-		types.NodeProjectFrameworkNitropack: true,
-		types.NodeProjectFrameworkAstro:     true,
-		types.NodeProjectFrameworkSvelte:    true,
-		types.NodeProjectFrameworkWaku:      true,
-		types.NodeProjectFrameworkAngular:   true,
-		types.NodeProjectFrameworkRemix:     true,
+		types.NodeProjectFrameworkNextJs:  true,
+		types.NodeProjectFrameworkAstro:   true,
+		types.NodeProjectFrameworkSvelte:  true,
+		types.NodeProjectFrameworkWaku:    true,
+		types.NodeProjectFrameworkAngular: true,
+		types.NodeProjectFrameworkRemix:   true,
+	}
+	for _, framework := range types.NitroBasedFrameworks {
+		defaultServerless[framework] = true
 	}
 
 	if serverless, ok := defaultServerless[framework]; ok {

--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -540,12 +540,7 @@ func TestGetStartCommand_Entry(t *testing.T) {
 		assert.Equal(t, "", startCmd)
 	})
 
-	nitroBasedFrameworks := []types.NodeProjectFramework{
-		types.NodeProjectFrameworkNuxtJs,
-		types.NodeProjectFrameworkNitropack,
-	}
-
-	for _, framework := range nitroBasedFrameworks {
+	for _, framework := range types.NitroBasedFrameworks {
 		t.Run("nitro-"+string(framework), func(t *testing.T) {
 			t.Run("nodejs", func(t *testing.T) {
 				fs := afero.NewMemMapFs()

--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -577,3 +577,37 @@ func TestGetStartCommand_Entry(t *testing.T) {
 		})
 	}
 }
+
+func TestGetServerless(t *testing.T) {
+	t.Parallel()
+
+	for _, nitroFramework := range types.NitroBasedFrameworks {
+		t.Run("nitro-"+string(nitroFramework), func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			_ = afero.WriteFile(fs, "package.json", []byte(`{}`), 0o644)
+
+			ctx := &nodePlanContext{
+				Src:                fs,
+				Config:             plan.NewProjectConfigurationFromFs(fs, ""),
+				ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
+				Framework:          optional.Some(nitroFramework),
+			}
+
+			assert.True(t, getServerless(ctx))
+		})
+	}
+
+	t.Run("unknown", func(t *testing.T) {
+		fs := afero.NewMemMapFs()
+		_ = afero.WriteFile(fs, "package.json", []byte(`{}`), 0o644)
+
+		ctx := &nodePlanContext{
+			Src:                fs,
+			Config:             plan.NewProjectConfigurationFromFs(fs, ""),
+			ProjectPackageJSON: lo.Must(DeserializePackageJSON(fs)),
+			Framework:          optional.Some[types.NodeProjectFramework](""),
+		}
+
+		assert.False(t, getServerless(ctx))
+	})
+}

--- a/internal/nodejs/template_test.go
+++ b/internal/nodejs/template_test.go
@@ -172,6 +172,7 @@ func TestTemplate_NitroPreset(t *testing.T) {
 				result, err := ctx.Execute()
 				assert.NoError(t, err)
 				assert.Contains(t, result, "ENV NITRO_PRESET=node-server")
+				assert.Contains(t, result, "ENV HOST=0.0.0.0")
 			})
 
 			t.Run("bun", func(t *testing.T) {
@@ -189,6 +190,7 @@ func TestTemplate_NitroPreset(t *testing.T) {
 				result, err := ctx.Execute()
 				assert.NoError(t, err)
 				assert.Contains(t, result, "ENV NITRO_PRESET=bun")
+				assert.Contains(t, result, "ENV HOST=0.0.0.0")
 			})
 
 			t.Run("node", func(t *testing.T) {

--- a/internal/nodejs/templates/template.Dockerfile
+++ b/internal/nodejs/templates/template.Dockerfile
@@ -22,7 +22,7 @@ RUN corepack enable
 {{ .InstallCmd }}
 
 {{ if eq .AppDir "" }}COPY . .{{ end }}
-{{ if or (eq .Framework "nuxt.js") (eq .Framework "nitropack") }}
+{{ if .Framework | isNitro }}
 {{ if .Serverless }}
 ENV NITRO_PRESET=node
 {{ else if and (not .Serverless) (prefixed .StartCmd "bun") }}

--- a/internal/nodejs/templates/template.Dockerfile
+++ b/internal/nodejs/templates/template.Dockerfile
@@ -27,8 +27,10 @@ RUN corepack enable
 ENV NITRO_PRESET=node
 {{ else if and (not .Serverless) (prefixed .StartCmd "bun") }}
 ENV NITRO_PRESET=bun
+ENV HOST=0.0.0.0
 {{ else }}
 ENV NITRO_PRESET=node-server
+ENV HOST=0.0.0.0
 {{ end }}
 {{ end }}
 # Build if we can build it

--- a/pkg/types/plan.go
+++ b/pkg/types/plan.go
@@ -1,6 +1,8 @@
 // Package types is the type definitions for the build plan in Zbpack.
 package types
 
+import "slices"
+
 // PlanType is primary category of the build plan.
 // For example, the programing language or the runtime.
 type PlanType string
@@ -80,6 +82,7 @@ const (
 	NodeProjectFrameworkSliDev           NodeProjectFramework = "sli.dev"
 	NodeProjectFrameworkDocusaurus       NodeProjectFramework = "docusaurus"
 	NodeProjectFrameworkSolidStart       NodeProjectFramework = "solid-start"
+	NodeProjectFrameworkSolidStartV1     NodeProjectFramework = "solid-start-v1"
 	NodeProjectFrameworkSolidStartNode   NodeProjectFramework = "solid-start-node"
 	NodeProjectFrameworkSolidStartStatic NodeProjectFramework = "solid-start-static"
 	NodeProjectFrameworkNueJs            NodeProjectFramework = "nuejs"
@@ -88,6 +91,18 @@ const (
 	NodeProjectFrameworkGrammY           NodeProjectFramework = "grammy"
 	NodeProjectFrameworkNitropack        NodeProjectFramework = "nitropack"
 )
+
+var NitroBasedFrameworks = []NodeProjectFramework{
+	NodeProjectFrameworkNuxtJs,
+	NodeProjectFrameworkNitropack,
+	NodeProjectFrameworkSolidStartV1,
+}
+
+func IsNitroBasedFramework(framework string) bool {
+	return slices.ContainsFunc(NitroBasedFrameworks, func(f NodeProjectFramework) bool {
+		return string(f) == framework
+	})
+}
 
 //revive:enable:exported
 

--- a/pkg/types/plan.go
+++ b/pkg/types/plan.go
@@ -82,7 +82,7 @@ const (
 	NodeProjectFrameworkSliDev           NodeProjectFramework = "sli.dev"
 	NodeProjectFrameworkDocusaurus       NodeProjectFramework = "docusaurus"
 	NodeProjectFrameworkSolidStart       NodeProjectFramework = "solid-start"
-	NodeProjectFrameworkSolidStartV1     NodeProjectFramework = "solid-start-v1"
+	NodeProjectFrameworkSolidStartVinxi  NodeProjectFramework = "solid-start-vinxi"
 	NodeProjectFrameworkSolidStartNode   NodeProjectFramework = "solid-start-node"
 	NodeProjectFrameworkSolidStartStatic NodeProjectFramework = "solid-start-static"
 	NodeProjectFrameworkNueJs            NodeProjectFramework = "nuejs"
@@ -95,7 +95,7 @@ const (
 var NitroBasedFrameworks = []NodeProjectFramework{
 	NodeProjectFrameworkNuxtJs,
 	NodeProjectFrameworkNitropack,
-	NodeProjectFrameworkSolidStartV1,
+	NodeProjectFrameworkSolidStartVinxi,
 }
 
 func IsNitroBasedFramework(framework string) bool {

--- a/pkg/zeaburpack/main.go
+++ b/pkg/zeaburpack/main.go
@@ -413,7 +413,7 @@ func Build(opt *BuildOptions) error {
 		}
 	}
 
-	if (t == types.PlanTypeNodejs || t == types.PlanTypeBun) && (m["framework"] == string(types.NodeProjectFrameworkNuxtJs) || m["framework"] == string(types.NodeProjectFrameworkNitropack)) && m["serverless"] == "true" {
+	if (t == types.PlanTypeNodejs || t == types.PlanTypeBun) && types.IsNitroBasedFramework(m["framework"]) && m["serverless"] == "true" {
 		println("Transforming build output to serverless format ...")
 		err = nuxtjs.TransformServerless(*opt.Path)
 		if err != nil {


### PR DESCRIPTION
#### Description (required)

- Support SolidStart v1. It has been rewritten to Nitro (Vinxi), so I handle it in the separated logic.
- Refactor some Nitro logic to be generic.

#### Related issues & labels (optional)

- Closes ZEA-3587
- Suggested label: enhancement
