### PR TITLE
chore(planner/nodejs): Upgrade default Node version to 20

### DIFF
--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -440,9 +440,9 @@ func GetStartScript(ctx *nodePlanContext) string {
 }
 
 const (
-	defaultNodeVersion        = "18"
-	maxNodeVersion     uint64 = 21
-	maxLtsNodeVersion  uint64 = 18
+	defaultNodeVersion        = "20"
+	maxNodeVersion     uint64 = 22
+	maxLtsNodeVersion  uint64 = 20
 )
 
 func getNodeVersion(versionConstraint string) string {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description (required)

- Support Node v22
- Set default Node.js version to v20

#### Related issues & labels (optional)

- Closes none
- Suggested label: enhancement
