### PR TITLE
ZEA-3851: Build, Start, and Pre-start command in Rust

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -134,8 +134,8 @@ schema = 3
     version = "v1.11.0"
     hash = "sha256-+rV3cDZr13N8E0rJ7iHmwsKYKH+EhV+IXBut+JbBiIE="
   [mod."github.com/spf13/cast"]
-    version = "v1.6.0"
-    hash = "sha256-hxioqRZfXE0AE5099wmn3YG0AZF8Wda2EB4c7zHF6zI="
+    version = "v1.7.0"
+    hash = "sha256-xO2kSmNmMHaJ1i3T0ou0pcaBCusuO6Ep3xtF1P7ZadA="
   [mod."github.com/spf13/cobra"]
     version = "v1.8.1"
     hash = "sha256-yDF6yAHycV1IZOrt3/hofR+QINe+B2yqkcIaVov3Ky8="
@@ -176,14 +176,14 @@ schema = 3
     version = "v0.0.0-20240112132812-db7319d0e0e3"
     hash = "sha256-7fKt9/+xQDQOtrsAWd3+qcUtcZSgKhHNWGu4f6lNyyQ="
   [mod."golang.org/x/sync"]
-    version = "v0.7.0"
-    hash = "sha256-2ETllEu2GDWoOd/yMkOkLC2hWBpKzbVZ8LhjLu0d2A8="
+    version = "v0.8.0"
+    hash = "sha256-usvF0z7gq1vsX58p4orX+8WHlv52pdXgaueXlwj2Wss="
   [mod."golang.org/x/sys"]
     version = "v0.21.0"
     hash = "sha256-gapzPWuEqY36V6W2YhIDYR49sEvjJRd7bSuf9K1f4JY="
   [mod."golang.org/x/text"]
-    version = "v0.16.0"
-    hash = "sha256-hMTO45upjEuA4sJzGplJT+La2n3oAfHccfYWZuHcH+8="
+    version = "v0.17.0"
+    hash = "sha256-R8JbsP7KX+KFTHH7SjRnUGCdvtagylVOfngWEnVSqBc="
   [mod."golang.org/x/xerrors"]
     version = "v0.0.0-20231012003039-104605ab7028"
     hash = "sha256-IsFTm5WZQ6W1ZDF8WOP+6xiOAc7pIq8r9Afvkjp3PRQ="

--- a/internal/rust/plan.go
+++ b/internal/rust/plan.go
@@ -30,6 +30,10 @@ const ConfigRustAppDir = "rust.app_dir"
 // The assets will be copied to the root of the application.
 const ConfigRustAssets = "rust.assets"
 
+// ConfigPreStartCommand is the key for the command before `CMD`.
+// Useful for installing dependencies for runtime.
+const ConfigPreStartCommand = "pre_start_command"
+
 type rustPlanContext struct {
 	Src           afero.Fs
 	Config        plan.ImmutableProjectConfiguration
@@ -115,6 +119,18 @@ func needOpenssl(source afero.Fs) bool {
 	return false
 }
 
+func getBuildCommand(ctx *rustPlanContext) string {
+	return plan.Cast(ctx.Config.Get(plan.ConfigBuildCommand), cast.ToStringE).TakeOr("")
+}
+
+func getStartCommand(ctx *rustPlanContext) string {
+	return plan.Cast(ctx.Config.Get(plan.ConfigStartCommand), cast.ToStringE).TakeOr("")
+}
+
+func getPreStartCommand(ctx *rustPlanContext) string {
+	return plan.Cast(ctx.Config.Get(ConfigPreStartCommand), cast.ToStringE).TakeOr("")
+}
+
 // GetMeta gets the metadata of the Rust project.
 func GetMeta(options GetMetaOptions) types.PlanMeta {
 	ctx := &rustPlanContext{
@@ -129,7 +145,10 @@ func GetMeta(options GetMetaOptions) types.PlanMeta {
 		"entry":      getEntry(ctx),
 		"appDir":     getAppDir(ctx),
 		// assets/1:assets/2:...
-		"assets": strings.Join(getAssets(ctx), ":"),
+		"assets":          strings.Join(getAssets(ctx), ":"),
+		"buildCommand":    getBuildCommand(ctx),
+		"startCommand":    getStartCommand(ctx),
+		"preStartCommand": getPreStartCommand(ctx),
 	}
 
 	return meta

--- a/internal/rust/rust.go
+++ b/internal/rust/rust.go
@@ -22,6 +22,10 @@ type TemplateContext struct {
 	Entry      string
 	AppDir     string
 	Assets     []string
+
+	BuildCommand    string
+	StartCommand    string
+	PreStartCommand string
 }
 
 // GenerateDockerfile generates the Dockerfile for the Rust project.
@@ -31,11 +35,14 @@ func GenerateDockerfile(meta types.PlanMeta) (string, error) {
 	)
 
 	context := TemplateContext{
-		OpenSSL:    meta["openssl"] == "true",
-		Serverless: meta["serverless"] == "true",
-		Entry:      meta["entry"],
-		AppDir:     meta["appDir"],
-		Assets:     strings.FieldsFunc(meta["assets"], func(r rune) bool { return r == ':' }),
+		OpenSSL:         meta["openssl"] == "true",
+		Serverless:      meta["serverless"] == "true",
+		Entry:           meta["entry"],
+		AppDir:          meta["appDir"],
+		Assets:          strings.FieldsFunc(meta["assets"], func(r rune) bool { return r == ':' }),
+		BuildCommand:    meta["buildCommand"],
+		StartCommand:    meta["startCommand"],
+		PreStartCommand: meta["preStartCommand"],
 	}
 
 	var result bytes.Buffer

--- a/internal/rust/template.Dockerfile
+++ b/internal/rust/template.Dockerfile
@@ -3,6 +3,10 @@ FROM rust:1 AS builder
 WORKDIR /app
 COPY . /app
 
+{{ if ne .BuildCommand "" }}
+RUN {{ .BuildCommand }}
+{{ end }}
+
 # output to /out/bin
 RUN mkdir /out && cargo install --path "{{ .AppDir }}" --root /out
 
@@ -37,7 +41,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 {{ end }}
 
+{{ if ne .PreStartCommand "" }}
+RUN {{ .PreStartCommand }}
+{{ end }}
+
 COPY --from=post-builder /app /app
+{{ if ne .StartCommand "" }}
+CMD {{ .StartCommand }}
+{{ else }}
 CMD ["/app/main"]
+{{ end }}
 
 {{ end }}


### PR DESCRIPTION
#### Description (required)

- **chore: Update lockfile**
- **feat(planner/rust): Support Build/Start/Prestart commands**

#### Related issues & labels (optional)

- Closes ZEA-3851
- Suggested label: enhancement
