### PR TITLE
fix(planner/nodejs): Determine build command concat with &&

### DIFF
--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -850,10 +850,13 @@ func GetStaticOutputDir(ctx *nodePlanContext) string {
 		buildCommand := ctx.GetAppPackageJSON().Scripts[buildScriptName]
 
 		// Extract the outdir from the build script.
-		if outDir, ok := strings.CutPrefix(buildCommand, "vitepress build"); ok {
-			docsRoot := strings.TrimSpace(outDir)
-			*dir = optional.Some(filepath.Join(docsRoot, ".vitepress", "dist"))
-			return dir.Unwrap()
+		for _, buildCommandChunks := range strings.Split(buildCommand, "&&") {
+			buildCommandChunks = strings.TrimSpace(buildCommandChunks)
+			if outDir, ok := strings.CutPrefix(buildCommandChunks, "vitepress build"); ok {
+				docsRoot := strings.TrimSpace(outDir)
+				*dir = optional.Some(filepath.Join(docsRoot, ".vitepress", "dist"))
+				return dir.Unwrap()
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Description (required)

For example, `pnpm -C ../ run build && vitepress build`.

#### Related issues & labels (optional)

- Closes ZEA-4017
- Suggested label: bug
