### PR TITLE
fix(planner/ruby): Do not include patch version from Gemfile

### DIFF
--- a/internal/ruby/plan.go
+++ b/internal/ruby/plan.go
@@ -32,7 +32,7 @@ func DetermineRubyVersion(source afero.Fs, config plan.ImmutableProjectConfigura
 		return version
 	}
 
-	reg := regexp.MustCompile(`ruby ["'](\d+\.\d+\.\d+)["']`)
+	reg := regexp.MustCompile(`ruby ["'](\d+\.\d+)\.\d+["']`)
 	sourceFile, err := utils.ReadFileToUTF8(source, "Gemfile")
 	if err != nil {
 		return DefaultRubyVersion
@@ -43,6 +43,7 @@ func DetermineRubyVersion(source afero.Fs, config plan.ImmutableProjectConfigura
 		return DefaultRubyVersion
 	}
 
+	// strip the patch version, since it may be pretty old (for example, 2.7.0)
 	return matches[1]
 }
 

--- a/internal/ruby/plan_test.go
+++ b/internal/ruby/plan_test.go
@@ -16,7 +16,7 @@ func TestDetermineRubyVersion(t *testing.T) {
 	config := plan.NewProjectConfigurationFromFs(fs, "")
 
 	version := ruby.DetermineRubyVersion(fs, config)
-	assert.Equal(t, "2.7.2", version)
+	assert.Equal(t, "2.7", version)
 }
 
 func TestDetermineRubyVersion_Customized(t *testing.T) {


### PR DESCRIPTION
#### Description (required)

For a `Gemfile` with

```gemfile
ruby "2.7.2"
```

We only reserve the major and the minor version component, which is

```
2.7
```

#### Related issues & labels (optional)

- Closes ZEA-4053
- Suggested label: bug