### PR TITLE
ZEA-4056: Optimize folder find logic in githubfs

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -182,8 +182,8 @@ schema = 3
     version = "v0.21.0"
     hash = "sha256-gapzPWuEqY36V6W2YhIDYR49sEvjJRd7bSuf9K1f4JY="
   [mod."golang.org/x/text"]
-    version = "v0.17.0"
-    hash = "sha256-R8JbsP7KX+KFTHH7SjRnUGCdvtagylVOfngWEnVSqBc="
+    version = "v0.18.0"
+    hash = "sha256-aNvJW4gQs+MTfdz6DZqyyHQS2GJ9W8L8qKPVODPn4+k="
   [mod."golang.org/x/xerrors"]
     version = "v0.0.0-20231012003039-104605ab7028"
     hash = "sha256-IsFTm5WZQ6W1ZDF8WOP+6xiOAc7pIq8r9Afvkjp3PRQ="

--- a/internal/source/githubfs_black_test.go
+++ b/internal/source/githubfs_black_test.go
@@ -171,6 +171,19 @@ func TestGitHubFsOpen_Dir_Ref(t *testing.T) {
 	}
 }
 
+func TestGithubFs_Folder(t *testing.T) {
+	token := getGithubToken(t)
+
+	fs, err := source.NewGitHubFs("naiba", "nezha", token)
+	require.NoError(t, err)
+
+	f, err := fs.Open("")
+	require.NoError(t, err)
+
+	_, err = f.Stat()
+	require.NoError(t, err)
+}
+
 func TestReadLimited(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### Description (required)

```
$ zbpack -i https://github.com/naiba/nezha
2024/09/17 20:54:58 using submoduleName: nezha
2024/09/17 20:54:59 
╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ docker                                             ║
║───────────────────────────────────────────────────────────────────────║
║ expose           │ 8080                                               ║
...
```

#### Related issues & labels (optional)

- Closes ZEA-4056
- Suggested label: `bug`
