### PR TITLE
ZEA-4154: Allow specifying Dockerfile with environment variables

### DIFF
--- a/internal/dockerfile/dockerfile_test.go
+++ b/internal/dockerfile/dockerfile_test.go
@@ -14,7 +14,9 @@ func TestGenerateDockerFile(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "Dockerfile", []byte(expectedContent), 0o644)
 
-	ctx := GetMeta(GetMetaOptions{Src: fs})
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+
+	ctx := GetMeta(plan.NewPlannerOptions{Source: fs, Config: config})
 	packer := NewPacker()
 	actualContent, err := packer.GenerateDockerfile(ctx)
 
@@ -24,7 +26,9 @@ func TestGenerateDockerFile(t *testing.T) {
 
 func TestNoMatchedDockerfile(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	ctx := GetMeta(GetMetaOptions{Src: fs})
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+
+	ctx := GetMeta(plan.NewPlannerOptions{Source: fs, Config: config})
 
 	assert.Equal(t, plan.Continue(), ctx)
 }

--- a/internal/dockerfile/identify.go
+++ b/internal/dockerfile/identify.go
@@ -50,12 +50,7 @@ func (i *identify) Match(fs afero.Fs) bool {
 }
 
 func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
-	return GetMeta(
-		GetMetaOptions{
-			Src:           options.Source,
-			SubmoduleName: options.SubmoduleName,
-		},
-	)
+	return GetMeta(options)
 }
 
 var _ plan.Identifier = (*identify)(nil)

--- a/internal/dockerfile/plan.go
+++ b/internal/dockerfile/plan.go
@@ -20,18 +20,11 @@ import (
 )
 
 type dockerfilePlanContext struct {
-	src           afero.Fs
-	submoduleName string
+	plan.NewPlannerOptions
 
 	dockerfileName    optional.Option[string]
 	dockerfileContent optional.Option[[]byte]
 	ExposePort        optional.Option[string]
-}
-
-// GetMetaOptions is the options for GetMeta.
-type GetMetaOptions struct {
-	Src           afero.Fs
-	SubmoduleName string
 }
 
 // ErrNoDockerfile is the error when there is no Dockerfile in the project.
@@ -39,15 +32,16 @@ var ErrNoDockerfile = errors.New("no dockerfile in this environment")
 
 // FindDockerfile finds the Dockerfile in the project.
 func FindDockerfile(ctx *dockerfilePlanContext) (string, error) {
-	src := ctx.src
-	submoduleName := ctx.submoduleName
+	src := ctx.Source
+	dockerFilename := ctx.SubmoduleName
+
 	path := &ctx.dockerfileName
 
 	if path, err := ctx.dockerfileName.Take(); err == nil {
 		return path, nil
 	}
 
-	dockerFilename, err := findDockerfile(src, submoduleName)
+	dockerFilename, err := findDockerfile(src, dockerFilename)
 	if err != nil {
 		return "", err
 	}
@@ -56,7 +50,7 @@ func FindDockerfile(ctx *dockerfilePlanContext) (string, error) {
 	return path.Unwrap(), nil
 }
 
-func findDockerfile(fs afero.Fs, submoduleName string) (string, error) {
+func findDockerfile(fs afero.Fs, dockerfileName string) (string, error) {
 	converter := cases.Fold()
 
 	files, err := afero.ReadDir(fs, ".")
@@ -64,7 +58,7 @@ func findDockerfile(fs afero.Fs, submoduleName string) (string, error) {
 		return "", err
 	}
 
-	foldedSubmoduleName := converter.String(submoduleName)
+	foldedDockerfileName := converter.String(dockerfileName)
 
 	// Create a map of all the files in the directory.
 	// The filename here has been folded.
@@ -80,13 +74,13 @@ func findDockerfile(fs afero.Fs, submoduleName string) (string, error) {
 	// Check if there is a Dockerfile.[submoduleName] or
 	// [submoduleName].Dockerfile in the directory.
 	// If there is, return it.
-	if submoduleName != "" {
-		expectedFoldedFilename := "dockerfile." + foldedSubmoduleName
+	if dockerfileName != "" {
+		expectedFoldedFilename := "dockerfile." + foldedDockerfileName
 		if originalFilename, ok := filesMap[expectedFoldedFilename]; ok {
 			return originalFilename, nil
 		}
 
-		anotherExpectedFoldedFilename := foldedSubmoduleName + ".dockerfile"
+		anotherExpectedFoldedFilename := foldedDockerfileName + ".dockerfile"
 		if originalFilename, ok := filesMap[anotherExpectedFoldedFilename]; ok {
 			return originalFilename, nil
 		}
@@ -113,7 +107,7 @@ func ReadDockerfile(ctx *dockerfilePlanContext) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	content, err := utils.ReadFileToUTF8(ctx.src, dockerfileName)
+	content, err := utils.ReadFileToUTF8(ctx.Source, dockerfileName)
 	if err != nil {
 		return nil, err
 	}
@@ -155,10 +149,10 @@ func GetExposePort(ctx *dockerfilePlanContext) string {
 }
 
 // GetMeta gets the meta of the Dockerfile project.
-func GetMeta(opt GetMetaOptions) types.PlanMeta {
-	ctx := new(dockerfilePlanContext)
-	ctx.src = opt.Src
-	ctx.submoduleName = opt.SubmoduleName
+func GetMeta(opt plan.NewPlannerOptions) types.PlanMeta {
+	ctx := &dockerfilePlanContext{
+		NewPlannerOptions: opt,
+	}
 
 	dockerfileContent, err := ReadDockerfile(ctx)
 	if err != nil {

--- a/internal/dockerfile/plan.go
+++ b/internal/dockerfile/plan.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/moznion/go-optional"
 	"github.com/spf13/afero"
+	"github.com/spf13/cast"
 
 	"github.com/zeabur/zbpack/pkg/types"
 )
@@ -30,10 +31,20 @@ type dockerfilePlanContext struct {
 // ErrNoDockerfile is the error when there is no Dockerfile in the project.
 var ErrNoDockerfile = errors.New("no dockerfile in this environment")
 
+// ConfigDockerfileName is the key of the Dockerfile name in the config.
+const ConfigDockerfileName = "dockerfile.name"
+
 // FindDockerfile finds the Dockerfile in the project.
 func FindDockerfile(ctx *dockerfilePlanContext) (string, error) {
 	src := ctx.Source
-	dockerFilename := ctx.SubmoduleName
+	config := ctx.Config
+
+	// Get the Dockerfile name from the config.
+	// If there is not set, use the submodule as the Dockerfile name.
+	dockerFilename := plan.Cast(
+		config.Get("dockerfile.name"),
+		cast.ToStringE,
+	).TakeOr(ctx.SubmoduleName)
 
 	path := &ctx.dockerfileName
 

--- a/internal/dockerfile/plan_test.go
+++ b/internal/dockerfile/plan_test.go
@@ -5,14 +5,20 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/zbpack/pkg/plan"
 )
 
 func TestFindDockerfile_WithUppercase(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+
 	ctx := dockerfilePlanContext{
-		src: fs,
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
 	}
 	path, err := FindDockerfile(&ctx)
 
@@ -24,8 +30,13 @@ func TestFindDockerfile_WithLowercase(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "dockerfile", []byte("FROM alpine"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+
 	ctx := dockerfilePlanContext{
-		src: fs,
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
 	}
 	path, err := FindDockerfile(&ctx)
 
@@ -37,8 +48,13 @@ func TestFindDockerfile_WithRandomcase(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "dOckErFIle", []byte("FROM alpine"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+
 	ctx := dockerfilePlanContext{
-		src: fs,
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
 	}
 	path, err := FindDockerfile(&ctx)
 
@@ -51,9 +67,14 @@ func TestFindDockerfile_WithSubmodule(t *testing.T) {
 	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine"), 0o644)
 	_ = afero.WriteFile(fs, "Dockerfile.Subm", []byte("FROM ubuntu"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src:           fs,
-		submoduleName: "Subm",
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source:        fs,
+			Config:        config,
+			SubmoduleName: "Subm",
+		},
 	}
 	path, err := FindDockerfile(&ctx)
 
@@ -66,9 +87,14 @@ func TestFindDockerfile_CaseInsensitiveSubmodule(t *testing.T) {
 	_ = afero.WriteFile(fs, "dOckErFIle", []byte("FROM alpine"), 0o644)
 	_ = afero.WriteFile(fs, "dOckErFIle.SUbM", []byte("FROM alpine"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src:           fs,
-		submoduleName: "Subm",
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source:        fs,
+			Config:        config,
+			SubmoduleName: "Subm",
+		},
 	}
 	path, err := FindDockerfile(&ctx)
 
@@ -81,9 +107,14 @@ func TestFindDockerfile_WithSubmodulePrefixed(t *testing.T) {
 	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine"), 0o644)
 	_ = afero.WriteFile(fs, "Subm.Dockerfile", []byte("FROM ubuntu"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src:           fs,
-		submoduleName: "Subm",
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source:        fs,
+			Config:        config,
+			SubmoduleName: "Subm",
+		},
 	}
 	path, err := FindDockerfile(&ctx)
 
@@ -96,9 +127,14 @@ func TestFindDockerfile_PrefixedCaseInsensitiveSubmodule(t *testing.T) {
 	_ = afero.WriteFile(fs, "dOckErFIle", []byte("FROM alpine"), 0o644)
 	_ = afero.WriteFile(fs, "sUbM.dOckErFIle", []byte("FROM alpine"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src:           fs,
-		submoduleName: "Subm",
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source:        fs,
+			Config:        config,
+			SubmoduleName: "Subm",
+		},
 	}
 	path, err := FindDockerfile(&ctx)
 
@@ -111,9 +147,14 @@ func TestFindDockerfile_NoSuchSubmodule(t *testing.T) {
 	_ = afero.WriteFile(fs, "dOckErFIle", []byte("FROM alpine"), 0o644)
 	_ = afero.WriteFile(fs, "dOckErFIle.SUbM", []byte("FROM alpine"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src:           fs,
-		submoduleName: "Subm2",
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source:        fs,
+			Config:        config,
+			SubmoduleName: "Subm2",
+		},
 	}
 	path, err := FindDockerfile(&ctx)
 
@@ -125,8 +166,13 @@ func TestGetExposePort_WithExposeSpecified(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine\nEXPOSE 1145"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src: fs,
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
 	}
 	port := GetExposePort(&ctx)
 
@@ -137,8 +183,13 @@ func TestGetExposePort_WithoutExposeSpecified(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src: fs,
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
 	}
 	port := GetExposePort(&ctx)
 
@@ -149,8 +200,13 @@ func TestGetExposePort_WithLowercaseExposeSpecified(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine\nexpose 1145"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src: fs,
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
 	}
 	port := GetExposePort(&ctx)
 
@@ -161,8 +217,13 @@ func TestGetExposePort_WithLowercaseDockerfileSpecified(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "dockerfile", []byte("FROM alpine\nEXPOSE 1145"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src: fs,
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
 	}
 	port := GetExposePort(&ctx)
 
@@ -173,8 +234,13 @@ func TestGetExposePort_WithSpaceAfterExpose(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "dockerfile", []byte("FROM alpine\nEXPOSE 1145 "), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src: fs,
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
 	}
 	port := GetExposePort(&ctx)
 
@@ -185,8 +251,13 @@ func TestGetExposePort_WithLowercaseExpose(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "dockerfile", []byte("FROM alpine\nexpose 1145"), 0o644)
 
+	config := plan.NewProjectConfigurationFromFs(fs, "Subm")
+
 	ctx := dockerfilePlanContext{
-		src: fs,
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
 	}
 	port := GetExposePort(&ctx)
 
@@ -197,7 +268,9 @@ func TestGetMeta_Content(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine"), 0o644)
 
-	meta := GetMeta(GetMetaOptions{Src: fs})
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+
+	meta := GetMeta(plan.NewPlannerOptions{Source: fs, Config: config})
 
 	assert.Equal(t, "FROM alpine", meta["content"])
 }

--- a/internal/dockerfile/plan_test.go
+++ b/internal/dockerfile/plan_test.go
@@ -162,6 +162,26 @@ func TestFindDockerfile_NoSuchSubmodule(t *testing.T) {
 	assert.Equal(t, "dOckErFIle", path)
 }
 
+func TestFindDockerfile_WithConfig(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine"), 0o644)
+	_ = afero.WriteFile(fs, "Dockerfile.test", []byte("FROM ubuntu"), 0o644)
+
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+	config.Set("dockerfile.name", "test")
+
+	ctx := dockerfilePlanContext{
+		NewPlannerOptions: plan.NewPlannerOptions{
+			Source: fs,
+			Config: config,
+		},
+	}
+	path, err := FindDockerfile(&ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Dockerfile.test", path)
+}
+
 func TestGetExposePort_WithExposeSpecified(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine\nEXPOSE 1145"), 0o644)


### PR DESCRIPTION
#### Description (required)

Env: 
```
ZBPACK_DOCKERFILE_NAME="dbrunner-service" zbpack -i /tmp/backend-go/
2024/10/08 11:47:32 using submoduleName: backend-go
2024/10/08 11:47:32
╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ docker                                             ║
║───────────────────────────────────────────────────────────────────────║
║ expose           │ 8080                                               ║
║───────────────────────────────────────────────────────────────────────║
║ content          │ FROM golang:1.22-alpine3.20 AS builder             ║
║                  │                                                    ║
║                  │ WORKDIR /app                                       ║
║                  │                                                    ║
║                  │ RUN apk add --no-cache buf go-task --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing/ ║
║                  │                                                    ║
║                  │ COPY go.mod go.sum /app/                           ║
║                  │ RUN go mod download                                ║
║                  │                                                    ║
║                  │ COPY . /app/                                       ║
║                  │ RUN go-task build-dbrunner                         ║
║                  │                                                    ║
║                  │ FROM alpine:3.20                                   ║
║                  │ COPY --from=builder /app/out/dbrunner-service /service ║
║                  │ CMD ["/service"]                                   ║
║                  │                                                    ║
╚═══════════════════════════════════════════════════════════════════════╝
```

Default Dockerfile:

```
zbpack -i /tmp/backend-go/
2024/10/08 11:48:05 using submoduleName: backend-go
2024/10/08 11:48:05
╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ docker                                             ║
║───────────────────────────────────────────────────────────────────────║
║ expose           │ 8080                                               ║
╚═══════════════════════════════════════════════════════════════════════╝
```

Submodule:

```
zbpack -i /tmp/backend-go/
2024/10/08 11:48:27 using submoduleName: backend-go
2024/10/08 11:48:27
╔══════════════════════════════ Build Plan ═════════════════════════════╗
║ provider         │ docker                                             ║
║───────────────────────────────────────────────────────────────────────║
║ expose           │ 8080                                               ║
║───────────────────────────────────────────────────────────────────────║
║ content          │ FROM test                                          ║
║                  │                                                    ║
╚═══════════════════════════════════════════════════════════════════════╝
```

#### Related issues & labels (optional)

- Closes ZEA-4154
- Suggested label: enhancement 