### PR TITLE
Add serverless field to static artifact

### DIFF
--- a/internal/dart/identify.go
+++ b/internal/dart/identify.go
@@ -1,6 +1,7 @@
 package dart
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/moznion/go-optional"
@@ -111,6 +112,9 @@ func (i *identify) PlanMeta(options plan.NewPlannerOptions) types.PlanMeta {
 	}
 
 	if od := determineOutputDir(ctx); od != "" {
+		meta["serverless"] = strconv.FormatBool(
+			utils.GetExplicitServerlessConfig(ctx.Config).TakeOr(false),
+		)
 		meta["outputDir"] = od
 	}
 


### PR DESCRIPTION
#### Description (required)

Useful for packers to determine if we should build a static artifact
as a serverless bundle (`.zeabur`). If `serverless` is `false`, we
should fallback to the classial containerized (in another word, Nginx) mode.

- **feat(planner/nodejs): Add "serverless" field to static artifact**
- **feat(planner/dart): Add "serverless" field to static artifact**

#### Related issues & labels (optional)

- Related to ZEA-4175
- Suggested label: enhancement
