### PR TITLE
Implement Python "uv" support

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -22,9 +22,6 @@ schema = 3
   [mod."github.com/evanw/esbuild"]
     version = "v0.24.0"
     hash = "sha256-Gyu9/5p8GitF3t9gQnsx/u0FNfkxWfKJWkgISBj6Lj0="
-  [mod."github.com/fatih/color"]
-    version = "v1.18.0"
-    hash = "sha256-pP5y72FSbi4j/BjyVq/XbAOFjzNjMxZt2R/lFFxGWvY="
   [mod."github.com/fsnotify/fsnotify"]
     version = "v1.8.0"
     hash = "sha256-+Rxg5q17VaqSU1xKPgurq90+Z1vzXwMLIBSe5UsyI/M="
@@ -38,8 +35,8 @@ schema = 3
     version = "v0.5.7"
     hash = "sha256-DCfko42wd7W9NadYPPX9c9H2HNH9DQHZTrfI9CTZqXQ="
   [mod."github.com/goccy/go-yaml"]
-    version = "v1.13.6"
-    hash = "sha256-gXK0tFZ1FhD84JfuXcQmZrbCX3HYAyUiiASCINRh9PA="
+    version = "v1.13.7"
+    hash = "sha256-d9W2+Ywo6WHV4C6JvkfU/DfO0KPxu7lYlR4PLHv94c8="
   [mod."github.com/gogo/protobuf"]
     version = "v1.3.2"
     hash = "sha256-pogILFrrk+cAtb0ulqn9+gRZJ7sGnnLLdtqITvxvG6c="
@@ -85,18 +82,12 @@ schema = 3
   [mod."github.com/maruel/natural"]
     version = "v1.1.1"
     hash = "sha256-eh5sNqcnxywonQ+56UAERpugr1jNxo7qJ+y09uOMChA="
-  [mod."github.com/mattn/go-colorable"]
-    version = "v0.1.13"
-    hash = "sha256-qb3Qbo0CELGRIzvw7NVM1g/aayaz4Tguppk9MD2/OI8="
-  [mod."github.com/mattn/go-isatty"]
-    version = "v0.0.20"
-    hash = "sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ="
   [mod."github.com/mitchellh/mapstructure"]
     version = "v1.5.0"
     hash = "sha256-ztVhGQXs67MF8UadVvG72G3ly0ypQW0IRDdOOkjYwoE="
   [mod."github.com/moby/buildkit"]
-    version = "v0.17.0"
-    hash = "sha256-L8j9QRsN4WUnDQWQnPzcZ/H/tsnG6YU/pXkbRME5w2M="
+    version = "v0.17.1"
+    hash = "sha256-8ko8Phv2FHUoGeEgEr1E+y+TfAZa8yoJCkLUKtIU8DQ="
   [mod."github.com/moznion/go-optional"]
     version = "v0.12.0"
     hash = "sha256-SCkBIo2GsDER5FnyPJknB+V5OC+Hltm9QIrfZK06vQg="
@@ -182,14 +173,14 @@ schema = 3
     version = "v0.0.0-20241009180824-f66d83c29e7c"
     hash = "sha256-ICL1UU2rrOBespsjNrlvrAhZOFLMcxYWAx8pDQCgAXM="
   [mod."golang.org/x/sync"]
-    version = "v0.8.0"
-    hash = "sha256-usvF0z7gq1vsX58p4orX+8WHlv52pdXgaueXlwj2Wss="
+    version = "v0.9.0"
+    hash = "sha256-sGvzGqaaXE5dxohKkpbJMnu+bMmismsSqr8YMtrK+Rc="
   [mod."golang.org/x/sys"]
     version = "v0.26.0"
     hash = "sha256-YjklsWNhx4g4TaWRWfFe1TMFKujbqiaNvZ38bfI35fM="
   [mod."golang.org/x/text"]
-    version = "v0.19.0"
-    hash = "sha256-C92pSYLLUQ2NKKcc60wpoSJ5UWAfnWkmd997C13fXdU="
+    version = "v0.20.0"
+    hash = "sha256-YP8zSo2e9okqhxVB8me8sJyij2O0tTQEg5t+8bsIUx8="
   [mod."google.golang.org/protobuf"]
     version = "v1.35.1"
     hash = "sha256-4NtUQoBvlPGFGjo7c+E1EBS/sb8oy50MGy45KGWPpWo="

--- a/internal/python/__snapshots__/plan_test.snap
+++ b/internal/python/__snapshots__/plan_test.snap
@@ -1,204 +1,204 @@
 
 [TestDetermineInstallCmd_Snapshot/pdm-none - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* .
+COPY pyproject.toml* pdm.lock* ./
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-fastapi - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* .
+COPY pyproject.toml* pdm.lock* ./
 RUN pdm add uvicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-static-django - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* .
+COPY pyproject.toml* pdm.lock* ./
 RUN pdm add gunicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-static-nginx - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* .
+COPY pyproject.toml* pdm.lock* ./
 RUN pdm add gunicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-static-nginx-django - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* .
+COPY pyproject.toml* pdm.lock* ./
 RUN pdm add gunicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-streamlit-entry - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* .
+COPY pyproject.toml* pdm.lock* ./
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-tornado - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* .
+COPY pyproject.toml* pdm.lock* ./
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-wsgi - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* .
+COPY pyproject.toml* pdm.lock* ./
 RUN pdm add gunicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-none - 1]
-COPY requirements.txt* .
+COPY requirements.txt* ./
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-fastapi - 1]
-COPY requirements.txt* .
+COPY requirements.txt* ./
 RUN pip install uvicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-static-django - 1]
-COPY requirements.txt* .
+COPY requirements.txt* ./
 RUN pip install gunicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-static-nginx - 1]
-COPY requirements.txt* .
+COPY requirements.txt* ./
 RUN pip install gunicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-static-nginx-django - 1]
-COPY requirements.txt* .
+COPY requirements.txt* ./
 RUN pip install gunicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-streamlit-entry - 1]
-COPY requirements.txt* .
+COPY requirements.txt* ./
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-tornado - 1]
-COPY requirements.txt* .
+COPY requirements.txt* ./
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-wsgi - 1]
-COPY requirements.txt* .
+COPY requirements.txt* ./
 RUN pip install gunicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-none - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* .
+COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-fastapi - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* .
+COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install uvicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-static-django - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* .
+COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install gunicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-static-nginx - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* .
+COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install gunicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-static-nginx-django - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* .
+COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install gunicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-streamlit-entry - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* .
+COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-tornado - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* .
+COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-wsgi - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* .
+COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install gunicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-none - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* .
+COPY pyproject.toml* poetry.lock* ./
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-fastapi - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* .
+COPY pyproject.toml* poetry.lock* ./
 RUN poetry add uvicorn
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-static-django - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* .
+COPY pyproject.toml* poetry.lock* ./
 RUN poetry add gunicorn
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-static-nginx - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* .
+COPY pyproject.toml* poetry.lock* ./
 RUN poetry add gunicorn
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-static-nginx-django - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* .
+COPY pyproject.toml* poetry.lock* ./
 RUN poetry add gunicorn
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-streamlit-entry - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* .
+COPY pyproject.toml* poetry.lock* ./
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-tornado - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* .
+COPY pyproject.toml* poetry.lock* ./
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-wsgi - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* .
+COPY pyproject.toml* poetry.lock* ./
 RUN poetry add gunicorn
 RUN poetry install
 ---

--- a/internal/python/pkgmanager.go
+++ b/internal/python/pkgmanager.go
@@ -15,6 +15,8 @@ func getPmInitCmd(pm types.PythonPackageManager) string {
 	case types.PythonPackageManagerPdm:
 		return "pip install pdm"
 	case types.PythonPackageManagerRye: // managed with pip
+	case types.PythonPackageManagerUv:
+		return "pip install uv"
 	}
 
 	return ""
@@ -33,6 +35,8 @@ func getPmAddCmd(pm types.PythonPackageManager, deps ...string) string {
 	case types.PythonPackageManagerPdm:
 		return "pdm add " + strings.Join(deps, " ")
 	case types.PythonPackageManagerRye: // managed with pip
+	case types.PythonPackageManagerUv:
+		return "uv add " + strings.Join(deps, " ")
 	}
 
 	return "pip install " + strings.Join(deps, " ")
@@ -50,6 +54,8 @@ func getPmInstallCmd(pm types.PythonPackageManager) string {
 		return "pdm install"
 	case types.PythonPackageManagerRye:
 		return "sed '/-e/d' requirements.lock | pip install -r /dev/stdin"
+	case types.PythonPackageManagerUv:
+		return "uv sync"
 	}
 
 	return ""
@@ -77,6 +83,8 @@ func getPmStartCmdPrefix(pm types.PythonPackageManager) string {
 		return "pdm run"
 	case types.PythonPackageManagerRye:
 		return "" // unneeded
+	case types.PythonPackageManagerUv:
+		return "uv run"
 	}
 
 	return ""
@@ -88,7 +96,7 @@ func getPmDeclarationFile(pm types.PythonPackageManager) string {
 		return "requirements.txt"
 	case types.PythonPackageManagerPipenv:
 		return "Pipfile"
-	case types.PythonPackageManagerPoetry, types.PythonPackageManagerPdm, types.PythonPackageManagerRye:
+	case types.PythonPackageManagerPoetry, types.PythonPackageManagerPdm, types.PythonPackageManagerRye, types.PythonPackageManagerUv:
 		return "pyproject.toml"
 	}
 
@@ -105,6 +113,8 @@ func getPmLockFile(pm types.PythonPackageManager) []string {
 		return []string{"pdm.lock"}
 	case types.PythonPackageManagerRye:
 		return []string{"requirements.lock"}
+	case types.PythonPackageManagerUv:
+		return []string{"uv.lock"}
 	}
 
 	return nil

--- a/internal/python/pkgmanager.go
+++ b/internal/python/pkgmanager.go
@@ -112,9 +112,9 @@ func getPmLockFile(pm types.PythonPackageManager) []string {
 	case types.PythonPackageManagerPdm:
 		return []string{"pdm.lock"}
 	case types.PythonPackageManagerRye:
-		return []string{"requirements.lock"}
+		return []string{"requirements.lock", ".python-version"}
 	case types.PythonPackageManagerUv:
-		return []string{"uv.lock"}
+		return []string{"uv.lock", ".python-version"}
 	}
 
 	return nil

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -515,18 +515,16 @@ func determineInstallCmd(ctx *pythonPlanContext) string {
 		filesToCopy = append(filesToCopy, decl+"*")
 	}
 	if lock := getPmLockFile(pm); len(lock) > 0 {
-		lockGlob := lo.Map(lock, func(s string, _ int) string {
-			return s + "*"
-		})
-
-		filesToCopy = append(filesToCopy, lockGlob...)
+		for _, f := range lock {
+			filesToCopy = append(filesToCopy, f+"*")
+		}
 	}
 
 	if cmd := getPmInitCmd(pm); cmd != "" {
 		commands = append(commands, "RUN "+cmd)
 	}
 	if len(filesToCopy) > 0 {
-		commands = append(commands, fmt.Sprintf("COPY %s .", strings.Join(filesToCopy, " ")))
+		commands = append(commands, fmt.Sprintf("COPY %s ./", strings.Join(filesToCopy, " ")))
 	}
 	if cmd := getPmAddCmd(pm, depToInstall...); cmd != "" {
 		commands = append(commands, "RUN "+cmd)

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -199,6 +199,11 @@ func DeterminePackageManager(ctx *pythonPlanContext) types.PythonPackageManager 
 		return cpm.Unwrap()
 	}
 
+	/* uv */
+	// If there is a uv.lock, we use uv.
+	if utils.HasFile(src, "uv.lock") {
+		*cpm = optional.Some(types.PythonPackageManagerUv)
+		return cpm.Unwrap()
 	}
 
 	*cpm = optional.Some(types.PythonPackageManagerUnknown)

--- a/internal/python/plan_test.go
+++ b/internal/python/plan_test.go
@@ -28,7 +28,8 @@ func TestPackageManager_Pip(t *testing.T) {
 	_ = afero.WriteFile(fs, "requirements.txt", nil, 0o644)
 
 	ctx := &pythonPlanContext{
-		Src: fs,
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
 	}
 	pm := DeterminePackageManager(ctx)
 
@@ -40,7 +41,8 @@ func TestPackageManager_Pipenv(t *testing.T) {
 	_ = afero.WriteFile(fs, "Pipfile", nil, 0o644)
 
 	ctx := &pythonPlanContext{
-		Src: fs,
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
 	}
 	pm := DeterminePackageManager(ctx)
 
@@ -71,7 +73,8 @@ build-backend = "poetry.core.masonry.api"
 `)), 0o644)
 
 	ctx := &pythonPlanContext{
-		Src: fs,
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
 	}
 	pm := DeterminePackageManager(ctx)
 
@@ -98,7 +101,8 @@ license = {text = "MIT"}
 	_ = afero.WriteFile(fs, "pdm.lock", nil, 0o644)
 
 	ctx := &pythonPlanContext{
-		Src: fs,
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
 	}
 	pm := DeterminePackageManager(ctx)
 
@@ -125,7 +129,8 @@ license = {text = "MIT"}
 	_ = afero.WriteFile(fs, "requirements.lock", nil, 0o644)
 
 	ctx := &pythonPlanContext{
-		Src: fs,
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
 	}
 	pm := DeterminePackageManager(ctx)
 
@@ -156,7 +161,8 @@ build-backend = "poetry.core.masonry.api"
 	_ = afero.WriteFile(fs, "requirements.txt", nil, 0o644)
 
 	ctx := &pythonPlanContext{
-		Src: fs,
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
 	}
 	pm := DeterminePackageManager(ctx)
 
@@ -184,7 +190,8 @@ license = {text = "MIT"}
 	_ = afero.WriteFile(fs, "requirements.txt", nil, 0o644)
 
 	ctx := &pythonPlanContext{
-		Src: fs,
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
 	}
 	pm := DeterminePackageManager(ctx)
 
@@ -197,7 +204,8 @@ func TestPackageManager_PipenvWithOldRequirements(t *testing.T) {
 	_ = afero.WriteFile(fs, "requirements.txt", nil, 0o644)
 
 	ctx := &pythonPlanContext{
-		Src: fs,
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
 	}
 	pm := DeterminePackageManager(ctx)
 
@@ -210,7 +218,8 @@ func TestPackageManager_PipenvWithOldRequirements_FixedOrder(t *testing.T) {
 	_ = afero.WriteFile(fs, "requirements.txt", nil, 0o644)
 
 	ctx := &pythonPlanContext{
-		Src: fs,
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
 	}
 
 	for i := 0; i < 1_000; i++ {
@@ -381,6 +390,7 @@ func TestHasDependency_Unknown(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerUnknown),
 	}
 
@@ -395,6 +405,7 @@ func TestHasDependency_Pip(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPip),
 	}
 
@@ -408,6 +419,7 @@ func TestHasDependency_Poetry(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPoetry),
 	}
 
@@ -421,6 +433,7 @@ func TestHasDependency_PoetryDep(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPoetry),
 	}
 
@@ -434,6 +447,7 @@ func TestHasDependency_Pipenv(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPipenv),
 	}
 
@@ -447,6 +461,7 @@ func TestHasDependency_PipenvDep(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPipenv),
 	}
 
@@ -461,6 +476,7 @@ func TestHasDependency_Pipenv_WithObsoleteRequirements(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPipenv),
 	}
 
@@ -475,6 +491,7 @@ func TestHasDependency_PipenvDep_WithObsoleteRequirements(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPipenv),
 	}
 
@@ -488,6 +505,7 @@ func TestHasDependency_Pip_HasMysqlClient(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPip),
 	}
 
@@ -500,6 +518,7 @@ func TestHasDependency_Pip_NoMysqlClient(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPip),
 	}
 
@@ -515,6 +534,7 @@ mysqlclient = "*"
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPipenv),
 	}
 
@@ -556,6 +576,7 @@ func TestHasDependency_Pipenv_DependOnMysqlClient(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPipenv),
 	}
 
@@ -600,6 +621,7 @@ mysqlalt = "*"
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPipenv),
 	}
 
@@ -615,6 +637,7 @@ mysqlclient = "^12.34.56"
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPoetry),
 	}
 
@@ -640,6 +663,7 @@ files = [
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPoetry),
 	}
 
@@ -665,6 +689,7 @@ files = [
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPoetry),
 	}
 
@@ -677,6 +702,7 @@ func TestHasDependency_CaseInsensitive(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPip),
 	}
 
@@ -690,6 +716,7 @@ func TestHasDependencyWithFile_Pip(t *testing.T) {
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPip),
 	}
 
@@ -714,6 +741,7 @@ pytest = "*"`), 0o644)
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPipenv),
 	}
 
@@ -743,6 +771,7 @@ build-backend = "poetry.core.masonry.api"`), 0o644)
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPoetry),
 	}
 
@@ -769,6 +798,7 @@ license = {text = "MIT"}`), 0o644)
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerPdm),
 	}
 
@@ -795,6 +825,7 @@ license = {text = "MIT"}`), 0o644)
 
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerRye),
 	}
 
@@ -806,6 +837,7 @@ func TestHasDependencyWithFile_Unknown(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ctx := &pythonPlanContext{
 		Src:            fs,
+		Config:         plan.NewProjectConfigurationFromFs(fs, ""),
 		PackageManager: optional.Some(types.PythonPackageManagerUnknown),
 	}
 

--- a/internal/python/plan_test.go
+++ b/internal/python/plan_test.go
@@ -137,6 +137,27 @@ license = {text = "MIT"}
 	assert.Equal(t, types.PythonPackageManagerRye, pm)
 }
 
+func TestPackageManager_Uv(t *testing.T) {
+	t.Parallel()
+
+	t.Run("contains uv.lock", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		_ = afero.WriteFile(fs, "pyproject.toml", nil, 0o644)
+		_ = afero.WriteFile(fs, "uv.lock", nil, 0o644)
+
+		ctx := &pythonPlanContext{
+			Src:    fs,
+			Config: plan.NewProjectConfigurationFromFs(fs, ""),
+		}
+
+		pm := DeterminePackageManager(ctx)
+
+		assert.Equal(t, types.PythonPackageManagerUv, pm)
+	})
+}
+
 func TestPackageManager_PoetryWithOldRequirements(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "pyproject.toml", []byte(strings.TrimSpace(`
@@ -226,6 +247,41 @@ func TestPackageManager_PipenvWithOldRequirements_FixedOrder(t *testing.T) {
 		pm := DeterminePackageManager(ctx)
 		assert.Equal(t, types.PythonPackageManagerPipenv, pm, fmt.Sprintf("in the test round %d", i))
 		ctx.PackageManager = nil
+	}
+}
+
+func TestPackageManager_Specified(t *testing.T) {
+	t.Parallel()
+
+	supportedPackageManagers := []types.PythonPackageManager{
+		types.PythonPackageManagerPip,
+		types.PythonPackageManagerPipenv,
+		types.PythonPackageManagerPoetry,
+		types.PythonPackageManagerPdm,
+		types.PythonPackageManagerRye,
+		types.PythonPackageManagerUv,
+	}
+
+	for _, pm := range supportedPackageManagers {
+		pm := pm
+
+		t.Run(string(pm), func(t *testing.T) {
+			t.Parallel()
+
+			fs := afero.NewMemMapFs()
+			config := plan.NewProjectConfigurationFromFs(fs, "")
+
+			config.Set(ConfigPythonPackageManager, string(pm))
+
+			ctx := pythonPlanContext{
+				Src:    fs,
+				Config: config,
+			}
+
+			determinedPm := DeterminePackageManager(&ctx)
+
+			assert.Equal(t, pm, determinedPm)
+		})
 	}
 }
 
@@ -710,7 +766,53 @@ func TestHasDependency_CaseInsensitive(t *testing.T) {
 	assert.False(t, HasDependency(ctx, "bar"))
 }
 
-func TestHasDependencyWithFile_Pip(t *testing.T) {
+func TestHasDependency_Uv(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "pyproject.toml", []byte(`
+[project]
+name = "midexam"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "matplotlib>=3.9.2",
+    "notebook>=7.2.2",
+    "pandas[output-formatting,performance,plot]>=2.2.3",
+    "polars[numpy,pandas,plot]>=1.13.1",
+    "scikit-learn>=1.5.2",
+    "seaborn>=0.13.2",
+]`), 0o644)
+	_ = afero.WriteFile(fs, "uv.lock", []byte(`version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "altair"
+version = "5.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/09/38904138a49f29e529b61b4f39954a6837f443d828c1bc57814be7bd4813/altair-5.4.1.tar.gz", hash = "sha256:0ce8c2e66546cb327e5f2d7572ec0e7c6feece816203215613962f0ec1d76a82", size = 636465 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/52/4a86a4fa1cc2aae79137cc9510b7080c3e5aede2310d14fae5486feec7f7/altair-5.4.1-py3-none-any.whl", hash = "sha256:0fb130b8297a569d08991fb6fe763582e7569f8a04643bbd9212436e3be04aef", size = 658150 },
+]`), 0o644)
+
+	ctx := &pythonPlanContext{
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
+	}
+
+	assert.True(t, HasDependency(ctx, "matplotlib"))
+	assert.True(t, HasDependency(ctx, "notebook"))
+	assert.True(t, HasDependency(ctx, "altair"))
+}
+
+func TestHasExplicitDependency_Pip(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "requirements.txt", []byte("foo"), 0o644)
 
@@ -724,7 +826,7 @@ func TestHasDependencyWithFile_Pip(t *testing.T) {
 	assert.False(t, HasExplicitDependency(ctx, "bar"))
 }
 
-func TestHasDependencyWithFile_Pipenv(t *testing.T) {
+func TestHasExplicitDependency_Pipenv(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "Pipfile", []byte(`
 [[source]]
@@ -749,7 +851,7 @@ pytest = "*"`), 0o644)
 	assert.False(t, HasExplicitDependency(ctx, "bar"))
 }
 
-func TestHasDependencyWithFile_Poetry(t *testing.T) {
+func TestHasExplicitDependency_Poetry(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "pyproject.toml", []byte(`
 [tool.poetry]
@@ -779,7 +881,7 @@ build-backend = "poetry.core.masonry.api"`), 0o644)
 	assert.False(t, HasExplicitDependency(ctx, "bar"))
 }
 
-func TestHasDependencyWithFile_Pdm(t *testing.T) {
+func TestHasExplicitDependency_Pdm(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "pyproject.toml", []byte(`
 
@@ -806,7 +908,7 @@ license = {text = "MIT"}`), 0o644)
 	assert.False(t, HasExplicitDependency(ctx, "bar"))
 }
 
-func TestHasDependencyWithFile_Rye(t *testing.T) {
+func TestHasExplicitDependency_Rye(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	_ = afero.WriteFile(fs, "pyproject.toml", []byte(`
 
@@ -833,7 +935,53 @@ license = {text = "MIT"}`), 0o644)
 	assert.False(t, HasExplicitDependency(ctx, "bar"))
 }
 
-func TestHasDependencyWithFile_Unknown(t *testing.T) {
+func TestHasExplicitDependency_Uv(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	_ = afero.WriteFile(fs, "pyproject.toml", []byte(`
+[project]
+name = "midexam"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "matplotlib>=3.9.2",
+    "notebook>=7.2.2",
+    "pandas[output-formatting,performance,plot]>=2.2.3",
+    "polars[numpy,pandas,plot]>=1.13.1",
+    "scikit-learn>=1.5.2",
+    "seaborn>=0.13.2",
+]`), 0o644)
+	_ = afero.WriteFile(fs, "uv.lock", []byte(`version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "altair"
+version = "5.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/09/38904138a49f29e529b61b4f39954a6837f443d828c1bc57814be7bd4813/altair-5.4.1.tar.gz", hash = "sha256:0ce8c2e66546cb327e5f2d7572ec0e7c6feece816203215613962f0ec1d76a82", size = 636465 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/52/4a86a4fa1cc2aae79137cc9510b7080c3e5aede2310d14fae5486feec7f7/altair-5.4.1-py3-none-any.whl", hash = "sha256:0fb130b8297a569d08991fb6fe763582e7569f8a04643bbd9212436e3be04aef", size = 658150 },
+]`), 0o644)
+
+	ctx := &pythonPlanContext{
+		Src:    fs,
+		Config: plan.NewProjectConfigurationFromFs(fs, ""),
+	}
+
+	assert.True(t, HasExplicitDependency(ctx, "matplotlib"))
+	assert.True(t, HasExplicitDependency(ctx, "notebook"))
+	assert.False(t, HasExplicitDependency(ctx, "altair"))
+}
+
+func TestHasExplicitDependency_Unknown(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	ctx := &pythonPlanContext{
 		Src:            fs,

--- a/internal/python/python.go
+++ b/internal/python/python.go
@@ -1,6 +1,8 @@
 package python
 
 import (
+	"strconv"
+
 	"github.com/zeabur/zbpack/pkg/packer"
 	"github.com/zeabur/zbpack/pkg/types"
 )
@@ -90,7 +92,7 @@ server { \
 COPY . .
 ` + buildCmd + `
 EXPOSE 8080
-CMD ` + startCmd
+CMD ["/bin/bash", "-c", ` + strconv.Quote(startCmd) + `]`
 
 	return dockerfile, nil
 }

--- a/pkg/types/plan.go
+++ b/pkg/types/plan.go
@@ -139,6 +139,7 @@ const (
 	PythonPackageManagerPipenv  PythonPackageManager = "pipenv"
 	PythonPackageManagerPdm     PythonPackageManager = "pdm"
 	PythonPackageManagerRye     PythonPackageManager = "rye"
+	PythonPackageManagerUv      PythonPackageManager = "uv"
 )
 
 type SwiftFramework string

--- a/tests/snapshots/python-django-static-whitenoise.txt
+++ b/tests/snapshots/python-django-static-whitenoise.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config"
   build: "RUN pip install -r requirements.txt\nRUN python manage.py collectstatic --noinput"
   framework: "django"
-  install: "COPY requirements.txt* .\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 core.wsgi; }; _startup"

--- a/tests/snapshots/python-django-static.txt
+++ b/tests/snapshots/python-django-static.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config nginx"
   build: "RUN pip install -r requirements.txt\nRUN python manage.py collectstatic --noinput"
   framework: "django"
-  install: "COPY requirements.txt* .\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { /usr/sbin/nginx && gunicorn --bind :8000 core.wsgi; }; _startup"

--- a/tests/snapshots/python-django.txt
+++ b/tests/snapshots/python-django.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config"
   build: "RUN pip install -r requirements.txt"
   framework: "django"
-  install: "COPY requirements.txt* .\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 mysite.wsgi; }; _startup"

--- a/tests/snapshots/python-fastapi.txt
+++ b/tests/snapshots/python-fastapi.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config"
   build: "RUN pip install -r requirements.txt"
   framework: "fastapi"
-  install: "COPY requirements.txt* .\nRUN pip install uvicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN pip install uvicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { uvicorn main:app --host 0.0.0.0 --port 8080; }; _startup"

--- a/tests/snapshots/python-flask-mysql.txt
+++ b/tests/snapshots/python-flask-mysql.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config"
   build: "RUN pip install -r requirements.txt"
   framework: "flask"
-  install: "COPY requirements.txt* .\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 app:app; }; _startup"

--- a/tests/snapshots/python-flask-static.txt
+++ b/tests/snapshots/python-flask-static.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config"
   build: "RUN pip install -r requirements.txt"
   framework: "flask"
-  install: "COPY requirements.txt* .\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 main:app; }; _startup"

--- a/tests/snapshots/python-flask.txt
+++ b/tests/snapshots/python-flask.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config"
   build: "RUN pip install -r requirements.txt"
   framework: "flask"
-  install: "COPY requirements.txt* .\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 app:app; }; _startup"

--- a/tests/snapshots/python-hnswlib.txt
+++ b/tests/snapshots/python-hnswlib.txt
@@ -3,7 +3,7 @@ PlanType: python
 Meta:
   apt-deps: "build-essential pkg-config"
   build: "RUN pip install -r requirements.txt"
-  install: "COPY requirements.txt* .\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { python app.py; }; _startup"

--- a/tests/snapshots/python-streamlit.txt
+++ b/tests/snapshots/python-streamlit.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config"
   build: "RUN pip install -r requirements.txt"
   framework: "streamlit"
-  install: "COPY requirements.txt* .\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { streamlit run streamlit_app.py --server.port=8080 --server.address=0.0.0.0; }; _startup"

--- a/tests/snapshots/python-zba651.txt
+++ b/tests/snapshots/python-zba651.txt
@@ -3,7 +3,7 @@ PlanType: python
 Meta:
   apt-deps: "build-essential pkg-config"
   build: "RUN pip install -r requirements.txt"
-  install: "COPY requirements.txt* .\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "COPY requirements.txt* ./\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { python main.py; }; _startup"


### PR DESCRIPTION
#### Description (required)

- **test(planner/python): Pass "config" to pythonPlanContext in tests**
- **refactor(planner/python): Simplify DeterminePackageManager**
- **feat(planner/python): Support uv package manager**
- **feat(planner/python): Allow specifying package manager**
- **test(python): Add uv tests**
- **fix(planner/python): Dockerfile issues**
- **feat(zbpack): Ignore more files in zbpack**

Add a new configuration (`python.package_manager`) to specify the package manager of this Python application.

#### Related issues & labels (optional)

- Closes ZEA-4300
- Suggested label: enhancement
