### PR TITLE
ZEA-4316: Disable caching dependencies by default in Node.js

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1727457166,
+        "lastModified": 1732121232,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "6090da46bfb53e358b818cee491df1a25daa85e0",
+        "rev": "6ff1e5f92c0d74bbb12f7454a239ca2f02e05ea1",
         "type": "github"
       },
       "original": {
@@ -36,10 +36,10 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
+        "lastModified": 1731533236,
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -76,10 +76,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1727478263,
+        "lastModified": 1729448365,
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "ba932692e249374e91bcbfe2e3a25ed3342a72eb",
+        "rev": "5d387097aa716f35dd99d848dc26d8d5b62a104c",
         "type": "github"
       },
       "original": {
@@ -90,10 +90,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727524699,
+        "lastModified": 1731890469,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b5b2fecd0cadd82ef107c9583018f381ae70f222",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
         "type": "github"
       },
       "original": {
@@ -105,10 +105,10 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1727540905,
+        "lastModified": 1731797254,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fbca5e745367ae7632731639de5c21f29c8744ed",
+        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
         "type": "github"
       },
       "original": {
@@ -128,10 +128,10 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1727514110,
+        "lastModified": 1732021966,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "85f7a7177c678de68224af3402ab8ee1bcee25c8",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -35,8 +35,8 @@ schema = 3
     version = "v0.5.7"
     hash = "sha256-DCfko42wd7W9NadYPPX9c9H2HNH9DQHZTrfI9CTZqXQ="
   [mod."github.com/goccy/go-yaml"]
-    version = "v1.13.7"
-    hash = "sha256-d9W2+Ywo6WHV4C6JvkfU/DfO0KPxu7lYlR4PLHv94c8="
+    version = "v1.14.3"
+    hash = "sha256-rdQctQ0723s4WRfhW960dJz545lG4oDMf2K/foiNPZA="
   [mod."github.com/gogo/protobuf"]
     version = "v1.3.2"
     hash = "sha256-pogILFrrk+cAtb0ulqn9+gRZJ7sGnnLLdtqITvxvG6c="

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -574,14 +574,14 @@ func GetInstallCmd(ctx *nodePlanContext) string {
 	needPlaywright := DetermineNeedPlaywright(ctx)
 	if needPlaywright {
 		cmds = append([]string{
-			"RUN apt-get update && apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdbus-1-3 libdrm2 libxkbcommon-x11-0 libxcomposite-dev libxdamage1 libxfixes-dev libxrandr2 libgbm-dev libasound2",
+			"RUN apt-get update && apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdbus-1-3 libdrm2 libxkbcommon-x11-0 libxcomposite-dev libxdamage1 libxfixes-dev libxrandr2 libgbm-dev libasound2 && rm -rf /var/lib/apt/lists/*",
 		}, cmds...)
 	}
 
 	needPuppeteer := DetermineNeedPuppeteer(ctx)
 	if needPuppeteer {
 		cmds = append([]string{
-			"RUN apt-get update && apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libgbm1 libasound2 libpangocairo-1.0-0 libxss1 libgtk-3-0 libxshmfence1 libglu1",
+			"RUN apt-get update && apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libgbm1 libasound2 libpangocairo-1.0-0 libxss1 libgtk-3-0 libxshmfence1 libglu1 && rm -rf /var/lib/apt/lists/*",
 			"ENV PUPPETEER_CACHE_DIR=/src/.cache/puppeteer",
 		}, cmds...)
 	}

--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -135,8 +135,8 @@ func TestGetInstallCmd_DefaultInstallCmd(t *testing.T) {
 	// RUN should be provided in planMeta
 	assert.Contains(t, installlCmd, "RUN ")
 
-	// for default installation command, cache are allowed.
-	assert.Contains(t, installlCmd, "COPY yarn.lock* .")
+	// for default installation command, cache is disabled.
+	assert.NotContains(t, installlCmd, "COPY yarn.lock* .")
 
 	// the installation command should be contained
 	assert.Contains(t, installlCmd, "yarn install")
@@ -360,7 +360,7 @@ func TestInstallCommand(t *testing.T) {
 		assert.Contains(t, installCmd, "WORKDIR /src/packages/service1")
 	})
 
-	t.Run("normal", func(t *testing.T) {
+	t.Run("normal (cache is disabled)", func(t *testing.T) {
 		t.Parallel()
 
 		fs := afero.NewMemMapFs()
@@ -373,7 +373,7 @@ func TestInstallCommand(t *testing.T) {
 		}
 
 		installCmd := GetInstallCmd(ctx)
-		assert.NotContains(t, installCmd, "COPY . .")
+		assert.Contains(t, installCmd, "COPY . .")
 		assert.NotContains(t, installCmd, "WORKDIR")
 	})
 

--- a/tests/snapshots/bun-bagel.txt
+++ b/tests/snapshots/bun-bagel.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "true"
   bunVersion: "latest"
   framework: "bagel"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY bun.lockb* .\nRUN bun install"
+  installCmd: "COPY . .\nRUN bun install"
   nodeVersion: "20"
   packageManager: "bun"
   startCmd: "bun run start"

--- a/tests/snapshots/bun-baojs.txt
+++ b/tests/snapshots/bun-baojs.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "true"
   bunVersion: "latest"
   framework: "baojs"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY bun.lockb* .\nRUN bun install"
+  installCmd: "COPY . .\nRUN bun install"
   nodeVersion: "20"
   packageManager: "bun"
   startCmd: "bun run start"

--- a/tests/snapshots/bun-elysia.txt
+++ b/tests/snapshots/bun-elysia.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "true"
   bunVersion: "latest"
   framework: "none"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY bun.lockb* .\nRUN bun install"
+  installCmd: "COPY . .\nRUN bun install"
   nodeVersion: "20"
   packageManager: "bun"
   startCmd: "bun run src/index.ts"

--- a/tests/snapshots/bun-nextjs.txt
+++ b/tests/snapshots/bun-nextjs.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "next.js"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY bun.lockb* .\nRUN bun install"
+  installCmd: "COPY . .\nRUN bun install"
   nodeVersion: "20"
   packageManager: "bun"
   serverless: "true"

--- a/tests/snapshots/bun-nuxtjs.txt
+++ b/tests/snapshots/bun-nuxtjs.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "true"
   bunVersion: "latest"
   framework: "nuxt.js"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY bun.lockb* .\nRUN bun install"
+  installCmd: "COPY . .\nRUN bun install"
   nodeVersion: "20"
   packageManager: "bun"
   serverless: "true"

--- a/tests/snapshots/bun-plain.txt
+++ b/tests/snapshots/bun-plain.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "true"
   bunVersion: "latest"
   framework: "none"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY bun.lockb* .\nRUN bun install"
+  installCmd: "COPY . .\nRUN bun install"
   nodeVersion: "20"
   packageManager: "bun"
   startCmd: "bun run start"

--- a/tests/snapshots/bun-without-lockfile.txt
+++ b/tests/snapshots/bun-without-lockfile.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "true"
   bunVersion: "latest"
   framework: "none"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY bun.lockb* .\nRUN bun install"
+  installCmd: "COPY . .\nRUN bun install"
   nodeVersion: "20"
   packageManager: "bun"
   startCmd: "bun run src/index.ts"

--- a/tests/snapshots/bun-yarn-lockfile.txt
+++ b/tests/snapshots/bun-yarn-lockfile.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "true"
   bunVersion: "latest"
   framework: "none"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY bun.lockb* .\nRUN bun install"
+  installCmd: "COPY . .\nRUN bun install"
   nodeVersion: "20"
   packageManager: "bun"
   startCmd: "bun run start"

--- a/tests/snapshots/node-astro.txt
+++ b/tests/snapshots/node-astro.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "astro"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/node-sveltekit.txt
+++ b/tests/snapshots/node-sveltekit.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "svelte"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-a-lot-of-dependencies.txt
+++ b/tests/snapshots/nodejs-a-lot-of-dependencies.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "next.js"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY yarn.lock* .\nRUN yarn install"
+  installCmd: "COPY . .\nRUN yarn install"
   nodeVersion: "20"
   packageManager: "yarn"
   serverless: "true"

--- a/tests/snapshots/nodejs-angular.txt
+++ b/tests/snapshots/nodejs-angular.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "angular"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY package-lock.json* .\nRUN npm install"
+  installCmd: "COPY . .\nRUN npm install"
   nodeVersion: "20"
   outputDir: "dist/angular-template/browser"
   packageManager: "npm"

--- a/tests/snapshots/nodejs-docusaurus.txt
+++ b/tests/snapshots/nodejs-docusaurus.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "docusaurus"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "16"
   outputDir: "build"
   packageManager: "pnpm"

--- a/tests/snapshots/nodejs-expressjs.txt
+++ b/tests/snapshots/nodejs-expressjs.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "none"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/nodejs-foal.txt
+++ b/tests/snapshots/nodejs-foal.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "none"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "18"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/nodejs-nestjs.txt
+++ b/tests/snapshots/nodejs-nestjs.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "nest.js"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/nodejs-nextjs.txt
+++ b/tests/snapshots/nodejs-nextjs.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "next.js"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-nuejs.txt
+++ b/tests/snapshots/nodejs-nuejs.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "nuejs"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/nodejs-nuxtjs.txt
+++ b/tests/snapshots/nodejs-nuxtjs.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "nuxt.js"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-payload.txt
+++ b/tests/snapshots/nodejs-payload.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "next.js"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY yarn.lock* .\nRUN yarn install"
+  installCmd: "COPY . .\nRUN yarn install"
   nodeVersion: "20"
   packageManager: "yarn"
   serverless: "true"

--- a/tests/snapshots/nodejs-qwik-city.txt
+++ b/tests/snapshots/nodejs-qwik-city.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "qwik"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY package-lock.json* .\nRUN npm install"
+  installCmd: "COPY . .\nRUN npm install"
   nodeVersion: "15"
   packageManager: "npm"
   startCmd: "npm run deploy"

--- a/tests/snapshots/nodejs-remix.txt
+++ b/tests/snapshots/nodejs-remix.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "remix"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "18"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-rspress.txt
+++ b/tests/snapshots/nodejs-rspress.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "rspress"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   outputDir: "doc_build"
   packageManager: "pnpm"

--- a/tests/snapshots/nodejs-slidev.txt
+++ b/tests/snapshots/nodejs-slidev.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "sli.dev"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   outputDir: "dist"
   packageManager: "pnpm"

--- a/tests/snapshots/nodejs-starlight.txt
+++ b/tests/snapshots/nodejs-starlight.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "astro-starlight"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   outputDir: "dist"
   packageManager: "pnpm"

--- a/tests/snapshots/nodejs-umi.txt
+++ b/tests/snapshots/nodejs-umi.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "umi"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   outputDir: "dist"
   packageManager: "pnpm"

--- a/tests/snapshots/nodejs-vite-vanilla.txt
+++ b/tests/snapshots/nodejs-vite-vanilla.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "vite"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nRUN yarn install"
+  installCmd: "COPY . .\nRUN yarn install"
   nodeVersion: "20"
   outputDir: "dist"
   packageManager: "unknown"

--- a/tests/snapshots/nodejs-vitepress.txt
+++ b/tests/snapshots/nodejs-vitepress.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "vitepress"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   outputDir: "docs/.vitepress/dist"
   packageManager: "pnpm"

--- a/tests/snapshots/nodejs-vocs.txt
+++ b/tests/snapshots/nodejs-vocs.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "vocs"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   outputDir: "docs/dist"
   packageManager: "pnpm"

--- a/tests/snapshots/nodejs-waku.txt
+++ b/tests/snapshots/nodejs-waku.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "waku"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY pnpm-lock.yaml* .\nRUN pnpm install"
+  installCmd: "COPY . .\nRUN pnpm install"
   nodeVersion: "20"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/static-hexo.txt
+++ b/tests/snapshots/static-hexo.txt
@@ -6,7 +6,7 @@ Meta:
   bun: "false"
   bunVersion: "latest"
   framework: "hexo"
-  installCmd: "COPY package.json* tsconfig.json* .npmrc* .\nCOPY yarn.lock* .\nRUN yarn install"
+  installCmd: "COPY . .\nRUN yarn install"
   nodeVersion: "20"
   outputDir: "public"
   packageManager: "yarn"


### PR DESCRIPTION
#### Description (required)

- **chore(planner/nodejs): Clean up apt lists after installing dependencies**
- **fix(planner/nodejs): Disable caching dependencies by default**
- **chore: Update dependencies**

#### Related issues & labels (optional)

- Closes ZEA-4316
- Suggested label: enhancement
