### PR TITLE
ZEA-4362: Allow specifying the language and framework of a dockerfile

### DIFF
--- a/pkg/zeaburpack/injection_test.go
+++ b/pkg/zeaburpack/injection_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zeabur/zbpack/pkg/types"
 )
 
 func TestInjectDockerfile(t *testing.T) {
@@ -24,12 +25,16 @@ RUN echo world`
 			"KEY2": `"Value\""`,
 		}
 
-		injectedDockerfile := InjectDockerfile(dockerfile, &registry, variables)
+		injectedDockerfile := InjectDockerfile(dockerfile, &registry, variables, types.PlanTypeSwift, types.PlanMeta{
+			"framework": "vapor",
+		})
 
 		expectedDockerfile := `FROM test.io/library/alpine:3.12 AS builder
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -37,6 +42,8 @@ FROM test.io/library/alpine:3.12 AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
 
@@ -57,12 +64,16 @@ RUN echo world`
 			"KEY2": `"Value\""`,
 		}
 
-		injectedDockerfileWithoutRegistry := InjectDockerfile(dockerfile, nil, variables)
+		injectedDockerfileWithoutRegistry := InjectDockerfile(dockerfile, nil, variables, types.PlanTypeSwift, types.PlanMeta{
+			"framework": "vapor",
+		})
 
 		expectedDockerfileWithoutRegistry := `FROM alpine:3.12 AS builder
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -70,6 +81,8 @@ FROM alpine:3.12 AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
 
@@ -91,12 +104,16 @@ RUN echo world`
 			"KEY2": `"Value\""`,
 		}
 
-		injectedDockerfile := InjectDockerfile(dockerfile, &registry, variables)
+		injectedDockerfile := InjectDockerfile(dockerfile, &registry, variables, types.PlanTypeSwift, types.PlanMeta{
+			"framework": "vapor",
+		})
 
 		expectedDockerfile := `FROM test.io/library/alpine:3.12 AS builder
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -104,6 +121,8 @@ FROM builder AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
 
@@ -124,12 +143,16 @@ RUN echo world`
 			"KEY2": `"Value\""`,
 		}
 
-		injectedDockerfile := InjectDockerfile(dockerfile, nil, variables)
+		injectedDockerfile := InjectDockerfile(dockerfile, nil, variables, types.PlanTypeSwift, types.PlanMeta{
+			"framework": "vapor",
+		})
 
 		expectedDockerfile := `FROM alpine:3.12 AS builder
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -137,6 +160,8 @@ FROM builder AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
 
@@ -157,12 +182,16 @@ RUN echo world`
 			"KEY2": `"Value\""`,
 		}
 
-		injectedDockerfile := InjectDockerfile(dockerfile, nil, variables)
+		injectedDockerfile := InjectDockerfile(dockerfile, nil, variables, types.PlanTypeSwift, types.PlanMeta{
+			"framework": "vapor",
+		})
 
 		expectedDockerfile := `FROM alpine:3.12 AS builder
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -170,8 +199,32 @@ FROM builder AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
+LABEL com.zeabur.zbpack.language="swift"
+LABEL com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
+
+		assert.Equal(t, injectedDockerfile, expectedDockerfile)
+	})
+
+	t.Run("without framework", func(t *testing.T) {
+		t.Parallel()
+
+		dockerfile := `FROM alpine:3.12 AS builder
+RUN echo hello`
+
+		variables := map[string]string{
+			"KEY": "VALUE",
+		}
+
+		injectedDockerfile := InjectDockerfile(dockerfile, nil, variables, types.PlanTypeDocker, types.PlanMeta{})
+
+		expectedDockerfile := `FROM alpine:3.12 AS builder
+ENV KEY="VALUE"
+
+LABEL com.zeabur.zbpack.language="docker"
+
+RUN echo hello`
 
 		assert.Equal(t, injectedDockerfile, expectedDockerfile)
 	})

--- a/pkg/zeaburpack/injection_test.go
+++ b/pkg/zeaburpack/injection_test.go
@@ -33,8 +33,7 @@ RUN echo world`
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -42,8 +41,7 @@ FROM test.io/library/alpine:3.12 AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
 
@@ -72,8 +70,7 @@ RUN echo world`
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -81,8 +78,7 @@ FROM alpine:3.12 AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
 
@@ -112,8 +108,7 @@ RUN echo world`
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -121,8 +116,7 @@ FROM builder AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
 
@@ -151,8 +145,7 @@ RUN echo world`
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -160,8 +153,7 @@ FROM builder AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
 
@@ -190,8 +182,7 @@ RUN echo world`
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo hello
 
@@ -199,8 +190,7 @@ FROM builder AS runner
 ENV KEY="VALUE"
 ENV KEY2="\"Value\\\"\""
 
-LABEL com.zeabur.zbpack.language="swift"
-LABEL com.zeabur.zbpack.framework="vapor"
+LABEL com.zeabur.zbpack.language="swift" com.zeabur.zbpack.framework="vapor"
 
 RUN echo world`
 
@@ -222,7 +212,7 @@ RUN echo hello`
 		expectedDockerfile := `FROM alpine:3.12 AS builder
 ENV KEY="VALUE"
 
-LABEL com.zeabur.zbpack.language="docker"
+LABEL com.zeabur.zbpack.language="docker" com.zeabur.zbpack.framework=""
 
 RUN echo hello`
 

--- a/pkg/zeaburpack/main.go
+++ b/pkg/zeaburpack/main.go
@@ -137,7 +137,7 @@ func Build(opt *BuildOptions) error {
 	_ = os.RemoveAll(path.Join(*opt.Path, ".zeabur"))
 
 	// Inject dockerfile to contain the variables, registry, etc.
-	newDockerfile := InjectDockerfile(dockerfile, opt.ProxyRegistry, *opt.UserVars)
+	newDockerfile := InjectDockerfile(dockerfile, opt.ProxyRegistry, *opt.UserVars, t, m)
 
 	err = buildImage(
 		&buildImageOptions{

--- a/pkg/zeaburpack/main.go
+++ b/pkg/zeaburpack/main.go
@@ -136,8 +136,12 @@ func Build(opt *BuildOptions) error {
 	// Remove .zeabur directory if exists
 	_ = os.RemoveAll(path.Join(*opt.Path, ".zeabur"))
 
+	labels := ExtractLabels(dockerfile)
+
 	// Inject dockerfile to contain the variables, registry, etc.
 	newDockerfile := InjectDockerfile(dockerfile, opt.ProxyRegistry, *opt.UserVars, t, m)
+
+	t, m = UpdatePlanMetaWithLabel(t, m, labels)
 
 	err = buildImage(
 		&buildImageOptions{


### PR DESCRIPTION
#### Description (required)

- **feat(zbpack): Put PlanType and PlanMeta to dockerfile**
- **feat(zbpack): Implement LABEL parser**
- **refactor(zbpack): Improve injector to use LABEL parser**
- **feat(zbpack): Implement injector**

#### Related issues & labels (optional)

- Closes ZEA-4362
- Suggested label: enhancement
