### PR TITLE
feat(planner/python): Install clang by default

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -8,8 +8,8 @@ schema = 3
     version = "v3.1.1"
     hash = "sha256-m97BzuMk+rlSfPUnYzWifqQBNNdrWZXhUlQwT2iY59A="
   [mod."github.com/containerd/typeurl/v2"]
-    version = "v2.2.2"
-    hash = "sha256-KF5UEQhYnMi2qDbCztD/EQV/VqTkNU/yG8S6KLMf68c="
+    version = "v2.2.3"
+    hash = "sha256-7hbXNe3LrJPgWbrvng8pYu9wgDp0IUvuCaq9wHhIrvs="
   [mod."github.com/davecgh/go-spew"]
     version = "v1.1.2-0.20180830191138-d8f796af33cc"
     hash = "sha256-fV9oI51xjHdOmEx6+dlq7Ku2Ag+m/bmbzPo6A4Y74qc="
@@ -35,8 +35,8 @@ schema = 3
     version = "v0.5.7"
     hash = "sha256-DCfko42wd7W9NadYPPX9c9H2HNH9DQHZTrfI9CTZqXQ="
   [mod."github.com/goccy/go-yaml"]
-    version = "v1.14.3"
-    hash = "sha256-rdQctQ0723s4WRfhW960dJz545lG4oDMf2K/foiNPZA="
+    version = "v1.15.7"
+    hash = "sha256-vdGe69/oeezlxmJ2NaloXmcZ3V+Ku5mOSg+NJi2AhoY="
   [mod."github.com/gogo/protobuf"]
     version = "v1.3.2"
     hash = "sha256-pogILFrrk+cAtb0ulqn9+gRZJ7sGnnLLdtqITvxvG6c="
@@ -86,8 +86,8 @@ schema = 3
     version = "v1.5.0"
     hash = "sha256-ztVhGQXs67MF8UadVvG72G3ly0ypQW0IRDdOOkjYwoE="
   [mod."github.com/moby/buildkit"]
-    version = "v0.17.2"
-    hash = "sha256-MTvjpKph4ykFU8umwxN2xS8k3L2CwMElHYaHTkCqIhA="
+    version = "v0.18.1"
+    hash = "sha256-yE3CXrZaNJcGir3HQapF76yhaY/jxMNe5VdvwY6/sPw="
   [mod."github.com/moznion/go-optional"]
     version = "v0.12.0"
     hash = "sha256-SCkBIo2GsDER5FnyPJknB+V5OC+Hltm9QIrfZK06vQg="
@@ -173,14 +173,14 @@ schema = 3
     version = "v0.0.0-20241009180824-f66d83c29e7c"
     hash = "sha256-ICL1UU2rrOBespsjNrlvrAhZOFLMcxYWAx8pDQCgAXM="
   [mod."golang.org/x/sync"]
-    version = "v0.9.0"
-    hash = "sha256-sGvzGqaaXE5dxohKkpbJMnu+bMmismsSqr8YMtrK+Rc="
+    version = "v0.10.0"
+    hash = "sha256-HWruKClrdoBKVdxKCyoazxeQV4dIYLdkHekQvx275/o="
   [mod."golang.org/x/sys"]
     version = "v0.26.0"
     hash = "sha256-YjklsWNhx4g4TaWRWfFe1TMFKujbqiaNvZ38bfI35fM="
   [mod."golang.org/x/text"]
-    version = "v0.20.0"
-    hash = "sha256-YP8zSo2e9okqhxVB8me8sJyij2O0tTQEg5t+8bsIUx8="
+    version = "v0.21.0"
+    hash = "sha256-QaMwddBRnoS2mv9Y86eVC2x2wx/GZ7kr2zAJvwDeCPc="
   [mod."google.golang.org/protobuf"]
     version = "v1.35.1"
     hash = "sha256-4NtUQoBvlPGFGjo7c+E1EBS/sb8oy50MGy45KGWPpWo="

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -551,7 +551,7 @@ func determineAptDependencies(ctx *pythonPlanContext) []string {
 		return []string{"caddy"}
 	}
 
-	deps := []string{"build-essential", "pkg-config"}
+	deps := []string{"build-essential", "pkg-config", "clang"}
 
 	// If we need to host static files, we need nginx.
 	staticPath := DetermineStaticInfo(ctx)

--- a/tests/snapshots/python-django-static-whitenoise.txt
+++ b/tests/snapshots/python-django-static-whitenoise.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config"
+  apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt\nRUN python manage.py collectstatic --noinput"
   framework: "django"
   install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"

--- a/tests/snapshots/python-django-static.txt
+++ b/tests/snapshots/python-django-static.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config nginx"
+  apt-deps: "build-essential pkg-config clang nginx"
   build: "RUN pip install -r requirements.txt\nRUN python manage.py collectstatic --noinput"
   framework: "django"
   install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"

--- a/tests/snapshots/python-django.txt
+++ b/tests/snapshots/python-django.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config"
+  apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "django"
   install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"

--- a/tests/snapshots/python-fastapi.txt
+++ b/tests/snapshots/python-fastapi.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config"
+  apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "fastapi"
   install: "COPY requirements.txt* ./\nRUN pip install uvicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"

--- a/tests/snapshots/python-flask-mysql.txt
+++ b/tests/snapshots/python-flask-mysql.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config"
+  apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "flask"
   install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"

--- a/tests/snapshots/python-flask-static.txt
+++ b/tests/snapshots/python-flask-static.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config"
+  apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "flask"
   install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"

--- a/tests/snapshots/python-flask.txt
+++ b/tests/snapshots/python-flask.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config"
+  apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "flask"
   install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"

--- a/tests/snapshots/python-hnswlib.txt
+++ b/tests/snapshots/python-hnswlib.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config"
+  apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   install: "COPY requirements.txt* ./\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"

--- a/tests/snapshots/python-streamlit.txt
+++ b/tests/snapshots/python-streamlit.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config"
+  apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "streamlit"
   install: "COPY requirements.txt* ./\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"

--- a/tests/snapshots/python-zba651.txt
+++ b/tests/snapshots/python-zba651.txt
@@ -1,7 +1,7 @@
 PlanType: python
 
 Meta:
-  apt-deps: "build-essential pkg-config"
+  apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   install: "COPY requirements.txt* ./\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"


### PR DESCRIPTION
#### Description (required)

Both mysqldb and psycog2 requires Clang now.

#### Related issues & labels (optional)

- Suggested label: enhancement
