### PR TITLE
feat(planner/golang): Allow specifying the entry point of a Go application

### DIFF
--- a/internal/golang/plan.go
+++ b/internal/golang/plan.go
@@ -14,6 +14,15 @@ import (
 	"github.com/zeabur/zbpack/pkg/types"
 )
 
+// ConfigGoEntry specifies the entry point of the a Go application.
+//
+// You should specify a full path to the entry point file, for example,
+// "cmd/server/main.go" or "app.go".
+//
+// If this key is not set, we discover it from "/main.go" and
+// "/cmd/<submodule>/main.go"
+const ConfigGoEntry = "go.entry"
+
 type goPlanContext struct {
 	Src    afero.Fs
 	Config plan.ImmutableProjectConfiguration
@@ -85,6 +94,11 @@ func getEntry(ctx *goPlanContext) string {
 	ent := &ctx.Entry
 	if entry, err := ent.Take(); err == nil {
 		return entry
+	}
+
+	if entry, err := plan.Cast(ctx.Config.Get(ConfigGoEntry), cast.ToStringE).Take(); err == nil {
+		*ent = optional.Some(entry)
+		return ent.Unwrap()
 	}
 
 	// in a basic go project, we assume the entrypoint is main.go in root directory

--- a/internal/golang/plan_test.go
+++ b/internal/golang/plan_test.go
@@ -10,6 +10,76 @@ import (
 	"github.com/zeabur/zbpack/pkg/plan"
 )
 
+func TestGetEntry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without entry", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "test")
+
+		ctx := &goPlanContext{
+			Src:    fs,
+			Config: config,
+		}
+
+		entry := getEntry(ctx)
+		assert.Equal(t, "", entry)
+	})
+
+	t.Run("with root main.go", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "test")
+		_ = afero.WriteFile(fs, "main.go", nil, 0o644)
+
+		ctx := &goPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "server",
+		}
+
+		entry := getEntry(ctx)
+		assert.Equal(t, "", entry)
+	})
+
+	t.Run("with submodule", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "test")
+
+		_ = afero.WriteFile(fs, "cmd/server/main.go", nil, 0o644)
+
+		ctx := &goPlanContext{
+			Src:           fs,
+			Config:        config,
+			SubmoduleName: "server",
+		}
+
+		entry := getEntry(ctx)
+		assert.Equal(t, "cmd/server/main.go", entry)
+	})
+
+	t.Run("with entry", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		config := plan.NewProjectConfigurationFromFs(fs, "test")
+		config.Set(ConfigGoEntry, "cmd/server/main.go")
+
+		ctx := &goPlanContext{
+			Src:    fs,
+			Config: config,
+		}
+
+		entry := getEntry(ctx)
+		assert.Equal(t, "cmd/server/main.go", entry)
+	})
+}
+
 func TestGetBuildCommand(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### Description (required)

Add a new config `ZBPACK_GO_ENTRY` (`go.entry`) to allow users specifying the entry point of application explicitly.

Useful for replicas (`app-1`, `app-2`, `app-3`) and custom structure of code.

#### Related issues & labels (optional)

- Closes ZEA-4416
- Suggested label: enhancement
