### PR TITLE
ZEA-4475: Python: Do not cache dependency installation layer

### DIFF
--- a/internal/python/__snapshots__/plan_test.snap
+++ b/internal/python/__snapshots__/plan_test.snap
@@ -1,204 +1,172 @@
 
 [TestDetermineInstallCmd_Snapshot/pdm-none - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* ./
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-fastapi - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* ./
 RUN pdm add uvicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-static-django - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* ./
 RUN pdm add gunicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-static-nginx - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* ./
 RUN pdm add gunicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-static-nginx-django - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* ./
 RUN pdm add gunicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-streamlit-entry - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* ./
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-tornado - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* ./
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pdm-with-wsgi - 1]
 RUN pip install pdm
-COPY pyproject.toml* pdm.lock* ./
 RUN pdm add gunicorn
 RUN pdm install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-none - 1]
-COPY requirements.txt* ./
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-fastapi - 1]
-COPY requirements.txt* ./
 RUN pip install uvicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-static-django - 1]
-COPY requirements.txt* ./
 RUN pip install gunicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-static-nginx - 1]
-COPY requirements.txt* ./
 RUN pip install gunicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-static-nginx-django - 1]
-COPY requirements.txt* ./
 RUN pip install gunicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-streamlit-entry - 1]
-COPY requirements.txt* ./
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-tornado - 1]
-COPY requirements.txt* ./
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pip-with-wsgi - 1]
-COPY requirements.txt* ./
 RUN pip install gunicorn
 RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-none - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-fastapi - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install uvicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-static-django - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install gunicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-static-nginx - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install gunicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-static-nginx-django - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install gunicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-streamlit-entry - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-tornado - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/pipenv-with-wsgi - 1]
 RUN pip install pipenv
-COPY Pipfile* Pipfile.lock* ./
 RUN pipenv install gunicorn
 RUN pipenv install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-none - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* ./
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-fastapi - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* ./
 RUN poetry add uvicorn
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-static-django - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* ./
 RUN poetry add gunicorn
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-static-nginx - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* ./
 RUN poetry add gunicorn
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-static-nginx-django - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* ./
 RUN poetry add gunicorn
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-streamlit-entry - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* ./
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-tornado - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* ./
 RUN poetry install
 ---
 
 [TestDetermineInstallCmd_Snapshot/poetry-with-wsgi - 1]
 RUN pip install poetry
-COPY pyproject.toml* poetry.lock* ./
 RUN poetry add gunicorn
 RUN poetry install
 ---

--- a/internal/python/plan.go
+++ b/internal/python/plan.go
@@ -510,21 +510,8 @@ func determineInstallCmd(ctx *pythonPlanContext) string {
 		}
 	}
 
-	var filesToCopy []string
-	if decl := getPmDeclarationFile(pm); decl != "" {
-		filesToCopy = append(filesToCopy, decl+"*")
-	}
-	if lock := getPmLockFile(pm); len(lock) > 0 {
-		for _, f := range lock {
-			filesToCopy = append(filesToCopy, f+"*")
-		}
-	}
-
 	if cmd := getPmInitCmd(pm); cmd != "" {
 		commands = append(commands, "RUN "+cmd)
-	}
-	if len(filesToCopy) > 0 {
-		commands = append(commands, fmt.Sprintf("COPY %s ./", strings.Join(filesToCopy, " ")))
 	}
 	if cmd := getPmAddCmd(pm, depToInstall...); cmd != "" {
 		commands = append(commands, "RUN "+cmd)

--- a/internal/python/python.go
+++ b/internal/python/python.go
@@ -45,8 +45,8 @@ CMD ` + startCmd, nil
 	if serverless == "true" {
 		return `FROM docker.io/library/python:` + pyVer + `-slim AS builder
 WORKDIR /app
-` + installCmd + `
 COPY . .
+` + installCmd + `
 ` + buildCmd + `
 
 FROM scratch AS output
@@ -88,9 +88,7 @@ server { \
 }"> /etc/nginx/conf.d/default.conf` + "\n"
 	}
 
-	dockerfile += installCmd + `
-COPY . .
-` + buildCmd + `
+	dockerfile += "COPY . .\n" + installCmd + "\n" + buildCmd + `
 EXPOSE 8080
 CMD ["/bin/bash", "-c", ` + strconv.Quote(startCmd) + `]`
 

--- a/tests/real_project_test.go
+++ b/tests/real_project_test.go
@@ -378,8 +378,8 @@ var projects = []struct {
 	/* static */
 	{
 		name:  "static-html",
-		owner: "pan93412",
-		repo:  "homepage-plain",
+		owner: "schoolofdevops",
+		repo:  "html-sample-app",
 	},
 	{
 		name:  "static-mkdocs",

--- a/tests/snapshots/python-django-static-whitenoise.txt
+++ b/tests/snapshots/python-django-static-whitenoise.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt\nRUN python manage.py collectstatic --noinput"
   framework: "django"
-  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 core.wsgi; }; _startup"

--- a/tests/snapshots/python-django-static.txt
+++ b/tests/snapshots/python-django-static.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config clang nginx"
   build: "RUN pip install -r requirements.txt\nRUN python manage.py collectstatic --noinput"
   framework: "django"
-  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { /usr/sbin/nginx && gunicorn --bind :8000 core.wsgi; }; _startup"

--- a/tests/snapshots/python-django.txt
+++ b/tests/snapshots/python-django.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "django"
-  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 mysite.wsgi; }; _startup"

--- a/tests/snapshots/python-fastapi.txt
+++ b/tests/snapshots/python-fastapi.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "fastapi"
-  install: "COPY requirements.txt* ./\nRUN pip install uvicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN pip install uvicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { uvicorn main:app --host 0.0.0.0 --port 8080; }; _startup"

--- a/tests/snapshots/python-flask-mysql.txt
+++ b/tests/snapshots/python-flask-mysql.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "flask"
-  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 app:app; }; _startup"

--- a/tests/snapshots/python-flask-static.txt
+++ b/tests/snapshots/python-flask-static.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "flask"
-  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 main:app; }; _startup"

--- a/tests/snapshots/python-flask.txt
+++ b/tests/snapshots/python-flask.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "flask"
-  install: "COPY requirements.txt* ./\nRUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { gunicorn --bind :8080 app:app; }; _startup"

--- a/tests/snapshots/python-hnswlib.txt
+++ b/tests/snapshots/python-hnswlib.txt
@@ -3,7 +3,7 @@ PlanType: python
 Meta:
   apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
-  install: "COPY requirements.txt* ./\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { python app.py; }; _startup"

--- a/tests/snapshots/python-streamlit.txt
+++ b/tests/snapshots/python-streamlit.txt
@@ -4,7 +4,7 @@ Meta:
   apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
   framework: "streamlit"
-  install: "COPY requirements.txt* ./\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { streamlit run streamlit_app.py --server.port=8080 --server.address=0.0.0.0; }; _startup"

--- a/tests/snapshots/python-zba651.txt
+++ b/tests/snapshots/python-zba651.txt
@@ -3,7 +3,7 @@ PlanType: python
 Meta:
   apt-deps: "build-essential pkg-config clang"
   build: "RUN pip install -r requirements.txt"
-  install: "COPY requirements.txt* ./\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
+  install: "RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
   pythonVersion: "3.10"
   start: "_startup() { python main.py; }; _startup"


### PR DESCRIPTION
#### Description (required)

- **fix(planner/python): Remove bad caching**
- **chore: Update E2E test repo**
- **chore: Update snapshot**

#### Related issues & labels (optional)

- Closes ZEA-4475
- Suggested label: bug
