### PR TITLE
revert(planner/nodejs): Implement multi-layer build for Node.js

### DIFF
--- a/internal/nodejs/node.go
+++ b/internal/nodejs/node.go
@@ -18,11 +18,9 @@ type TemplateContext struct {
 
 	AppDir string
 
-	InstallCmd      string
-	BuildCmd        string
-	BuildRuntimeCmd string // currently only used by Medusa
-	StartCmd        string
-	RuntimeBaseDir  string // currently only used by Medusa
+	InstallCmd string
+	BuildCmd   string
+	StartCmd   string
 
 	Framework  string
 	Serverless bool
@@ -53,16 +51,14 @@ func (c TemplateContext) Execute() (string, error) {
 
 func getContextBasedOnMeta(meta types.PlanMeta) TemplateContext {
 	context := TemplateContext{
-		NodeVersion:     meta["nodeVersion"],
-		AppDir:          meta["appDir"],
-		InstallCmd:      meta["installCmd"],
-		BuildCmd:        meta["buildCmd"],
-		BuildRuntimeCmd: meta["buildRuntimeCmd"],
-		StartCmd:        meta["startCmd"],
-		RuntimeBaseDir:  meta["runtimeBaseDir"],
-		Framework:       meta["framework"],
-		Serverless:      meta["serverless"] == "true",
-		OutputDir:       meta["outputDir"],
+		NodeVersion: meta["nodeVersion"],
+		AppDir:      meta["appDir"],
+		InstallCmd:  meta["installCmd"],
+		BuildCmd:    meta["buildCmd"],
+		StartCmd:    meta["startCmd"],
+		Framework:   meta["framework"],
+		Serverless:  meta["serverless"] == "true",
+		OutputDir:   meta["outputDir"],
 
 		// The flag specific to planner/bun.
 		Bun:        meta["bun"] == "true" || meta["packageManager"] == "bun",

--- a/internal/nodejs/node_test.go
+++ b/internal/nodejs/node_test.go
@@ -63,23 +63,3 @@ func TestGetContextBasedOnMeta_WithOutputdirAndMPAFramework(t *testing.T) {
 		OutputDir:   "dist",
 	})
 }
-
-func TestGetContextBasedOnMeta_RuntimeEnvironment(t *testing.T) {
-	meta := getContextBasedOnMeta(types.PlanMeta{
-		"nodeVersion":     "16",
-		"installCmd":      "RUN npm install",
-		"buildCmd":        "npm run build",
-		"buildRuntimeCmd": "npm run build-runtime",
-		"startCmd":        "npm run start",
-		"runtimeBaseDir":  "/src/.output",
-	})
-
-	assert.Equal(t, meta, TemplateContext{
-		NodeVersion:     "16",
-		InstallCmd:      "RUN npm install",
-		BuildCmd:        "npm run build",
-		BuildRuntimeCmd: "npm run build-runtime",
-		StartCmd:        "npm run start",
-		RuntimeBaseDir:  "/src/.output",
-	})
-}

--- a/internal/nodejs/templates/template.Dockerfile
+++ b/internal/nodejs/templates/template.Dockerfile
@@ -34,14 +34,6 @@ COPY --from=build /src/{{ .AppDir }}/{{ .OutputDir }} /
 FROM zeabur/caddy-static AS runtime
 COPY --from=output / /usr/share/caddy
 {{ end }}
-{{ else if ne .RuntimeBaseDir "" }}
-FROM build AS prod
-COPY --from=build {{ .RuntimeBaseDir }} /app/
-WORKDIR /app
-
-EXPOSE 8080
-RUN {{ .BuildRuntimeCmd }}
-CMD {{ .StartCmd }}
 {{ else }}
 EXPOSE 8080
 CMD {{ .StartCmd }}{{ end }}

--- a/tests/real_project_test.go
+++ b/tests/real_project_test.go
@@ -280,6 +280,11 @@ var projects = []struct {
 		repo:  "medusa-starter-default",
 	},
 	{
+		name:  "nodejs-medusa-zb",
+		owner: "zeabur",
+		repo:  "medusa-starter-default",
+	},
+	{
 		name: "nodejs-a-lot-of-dependencies",
 		dir:  "nodejs-a-lot-of-dependencies",
 	},

--- a/tests/snapshots/nodejs-medusa-zb.txt
+++ b/tests/snapshots/nodejs-medusa-zb.txt
@@ -8,4 +8,4 @@ Meta:
   installCmd: "COPY . .\nRUN yarn install"
   nodeVersion: "20"
   packageManager: "yarn"
-  startCmd: "cd .medusa/server && yarn start"
+  startCmd: "cd .medusa/server && yarn predeploy && yarn start"


### PR DESCRIPTION
#### Description (required)

There are some modules that needs the source code tree. Therefore, we will not only copy `.medusa/server` now.

This reverts commit 4c59e19952edccb594ea16e3564801df2524d946.

#### Related issues & labels (optional)

- Experiments
- Suggested label: enhancement
