### PR TITLE
ZEA-4591: Lock available Node.js version on major version

### DIFF
--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -545,18 +545,44 @@ const (
 	defaultNodeVersion        = "22"
 	maxNodeVersion     uint64 = 23
 	maxLtsNodeVersion  uint64 = 22
+	minNodeVersion     uint64 = 16
 )
 
-func getNodeVersion(versionConstraint string) string {
+func getNodeVersion(constraint string) string {
 	// .nvmrc extensions
-	if versionConstraint == "node" {
+	if constraint == "node" {
 		return strconv.FormatUint(maxNodeVersion, 10)
 	}
-	if versionConstraint == "lts/*" {
+	if constraint == "lts/*" {
 		return strconv.FormatUint(maxLtsNodeVersion, 10)
 	}
 
-	return utils.ConstraintToVersion(versionConstraint, defaultNodeVersion)
+	// For tilde versions or wildcards, clean the constraint to extract an exact version.
+	cleaned := constraint
+	if strings.HasPrefix(cleaned, "~") || strings.HasPrefix(cleaned, "=") {
+		cleaned = strings.TrimLeft(cleaned, "~=")
+	}
+	if strings.Contains(cleaned, "*") {
+		cleaned = strings.ReplaceAll(cleaned, "*", "0")
+	}
+
+	// Try to parse the cleaned version.
+	if v, err := semver.NewVersion(strings.TrimSpace(cleaned)); err == nil {
+		return strconv.FormatUint(max(v.Major(), minNodeVersion), 10)
+	}
+
+	// Otherwise, treat "constraint" as a range constraint.
+	constraints, err := semver.NewConstraint(constraint)
+	if err == nil {
+		for i := maxNodeVersion; i >= minNodeVersion; i-- {
+			v := semver.MustParse(fmt.Sprintf("%d.999.999", i))
+			if constraints.Check(v) {
+				return strconv.FormatUint(i, 10)
+			}
+		}
+	}
+
+	return defaultNodeVersion
 }
 
 // GetNodeVersion gets the Node.js version of the project.
@@ -567,11 +593,15 @@ func GetNodeVersion(ctx *nodePlanContext) string {
 
 	// If there are ".node-version" or ".nvmrc" file, we pick
 	// the version from them.
-	if content, err := utils.ReadFileToUTF8(src, ".node-version"); err == nil {
-		projectNodeVersion = strings.TrimSpace(string(content))
-	}
-	if content, err := utils.ReadFileToUTF8(src, ".nvmrc"); err == nil {
-		projectNodeVersion = strings.TrimSpace(string(content))
+	for _, f := range []string{".node-version", ".nvmrc"} {
+		content, err := utils.ReadFileToUTF8(src, f)
+		if err != nil {
+			continue
+		}
+
+		versionConstraint := strings.TrimSpace(string(content))
+
+		return getNodeVersion(versionConstraint)
 	}
 
 	return getNodeVersion(projectNodeVersion)

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -542,9 +542,9 @@ func GetScriptCommand(ctx *nodePlanContext, script string) string {
 }
 
 const (
-	defaultNodeVersion        = "20"
-	maxNodeVersion     uint64 = 22
-	maxLtsNodeVersion  uint64 = 20
+	defaultNodeVersion        = "22"
+	maxNodeVersion     uint64 = 23
+	maxLtsNodeVersion  uint64 = 22
 )
 
 func getNodeVersion(versionConstraint string) string {

--- a/internal/nodejs/plan_test.go
+++ b/internal/nodejs/plan_test.go
@@ -19,13 +19,18 @@ func TestGetNodeVersion_Empty(t *testing.T) {
 }
 
 func TestGetNodeVersion_Fixed(t *testing.T) {
-	v := getNodeVersion("10")
-	assert.Equal(t, "10", v)
+	v := getNodeVersion("16")
+	assert.Equal(t, "16", v)
+}
+
+func TestGetNodeVersion_TooOld(t *testing.T) {
+	v := getNodeVersion("0.10")
+	assert.Equal(t, "16", v)
 }
 
 func TestGetNodeVersion_Or(t *testing.T) {
-	v := getNodeVersion("^10 || ^12 || ^14")
-	assert.Equal(t, "14", v)
+	v := getNodeVersion("^18 || ^20")
+	assert.Equal(t, "20", v)
 }
 
 func TestGetNodeVersion_GreaterThanWithLessThan(t *testing.T) {
@@ -35,7 +40,7 @@ func TestGetNodeVersion_GreaterThanWithLessThan(t *testing.T) {
 
 func TestGetNodeVersion_GreaterThan(t *testing.T) {
 	v := getNodeVersion(">=4")
-	assert.Equal(t, "4", v) // FIXME: should be the latest?
+	assert.Equal(t, strconv.FormatUint(maxNodeVersion, 10), v)
 }
 
 func TestGetNodeVersion_LessThan(t *testing.T) {
@@ -45,12 +50,12 @@ func TestGetNodeVersion_LessThan(t *testing.T) {
 
 func TestGetNodeVersion_Exact(t *testing.T) {
 	v := getNodeVersion("16.0.0")
-	assert.Equal(t, "16.0", v)
+	assert.Equal(t, "16", v)
 }
 
 func TestGetNodeVersion_Exact_WithEqualOp(t *testing.T) {
 	v := getNodeVersion("=16.0.0")
-	assert.Equal(t, "16.0", v)
+	assert.Equal(t, "16", v)
 }
 
 func TestGetNodeVersion_CaretMinor(t *testing.T) {
@@ -60,12 +65,12 @@ func TestGetNodeVersion_CaretMinor(t *testing.T) {
 
 func TestGetNodeVersion_TildeMinor(t *testing.T) {
 	v := getNodeVersion("~16.0.1")
-	assert.Equal(t, "16.0", v)
+	assert.Equal(t, "16", v)
 }
 
 func TestGetNodeVersion_ExactWithWildcard(t *testing.T) {
 	v := getNodeVersion("16.0.*")
-	assert.Equal(t, "16.0", v)
+	assert.Equal(t, "16", v)
 }
 
 func TestGetNodeVersion_TildeWithWildcard(t *testing.T) {
@@ -85,7 +90,7 @@ func TestGetNodeVersion_NvmRcLatest(t *testing.T) {
 
 func TestGetNodeVersion_VPrefixedVersion(t *testing.T) {
 	v := getNodeVersion("v20.11.0")
-	assert.Equal(t, "20.11", v)
+	assert.Equal(t, "20", v)
 }
 
 func TestGetInstallCmd_CustomizeInstallCmd(t *testing.T) {

--- a/tests/snapshots/bun-bagel.txt
+++ b/tests/snapshots/bun-bagel.txt
@@ -8,6 +8,6 @@ Meta:
   framework: "bagel"
   initCmd: "RUN npm install -g bun@latest"
   installCmd: "RUN bun install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "bun"
   startCmd: "bun run start"

--- a/tests/snapshots/bun-baojs.txt
+++ b/tests/snapshots/bun-baojs.txt
@@ -8,6 +8,6 @@ Meta:
   framework: "baojs"
   initCmd: "RUN npm install -g bun@latest"
   installCmd: "RUN bun install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "bun"
   startCmd: "bun run start"

--- a/tests/snapshots/bun-elysia.txt
+++ b/tests/snapshots/bun-elysia.txt
@@ -8,6 +8,6 @@ Meta:
   framework: "none"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "pnpm"
   startCmd: "pnpm src/index.ts"

--- a/tests/snapshots/bun-nextjs.txt
+++ b/tests/snapshots/bun-nextjs.txt
@@ -8,7 +8,7 @@ Meta:
   framework: "next.js"
   initCmd: "RUN npm install -g bun@latest"
   installCmd: "RUN bun install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "bun"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/bun-nuxtjs.txt
+++ b/tests/snapshots/bun-nuxtjs.txt
@@ -8,7 +8,7 @@ Meta:
   framework: "nuxt.js"
   initCmd: "RUN npm install -g bun@latest"
   installCmd: "RUN bun install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "bun"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/bun-plain.txt
+++ b/tests/snapshots/bun-plain.txt
@@ -8,6 +8,6 @@ Meta:
   framework: "none"
   initCmd: "RUN npm install -g bun@latest"
   installCmd: "RUN bun install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "bun"
   startCmd: "bun run start"

--- a/tests/snapshots/bun-without-lockfile.txt
+++ b/tests/snapshots/bun-without-lockfile.txt
@@ -8,6 +8,6 @@ Meta:
   framework: "none"
   initCmd: "RUN npm install -g bun@latest"
   installCmd: "RUN bun install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "bun"
   startCmd: "bun run src/index.ts"

--- a/tests/snapshots/bun-yarn-lockfile.txt
+++ b/tests/snapshots/bun-yarn-lockfile.txt
@@ -8,6 +8,6 @@ Meta:
   framework: "none"
   initCmd: "RUN npm install -f -g yarn@latest"
   installCmd: "RUN yarn install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "yarn"
   startCmd: "yarn start"

--- a/tests/snapshots/node-astro.txt
+++ b/tests/snapshots/node-astro.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "astro"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "pnpm"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/node-sveltekit.txt
+++ b/tests/snapshots/node-sveltekit.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "svelte"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "pnpm"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/nodejs-a-lot-of-dependencies.txt
+++ b/tests/snapshots/nodejs-a-lot-of-dependencies.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "next.js"
   initCmd: "RUN npm install -f -g yarn@latest && yarn set version berry"
   installCmd: "RUN yarn install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "yarn"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/nodejs-angular.txt
+++ b/tests/snapshots/nodejs-angular.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "angular"
   initCmd: "RUN npm update -g npm"
   installCmd: "RUN npm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   outputDir: "dist/angular-template/browser"
   packageManager: "npm"
   serverless: "true"

--- a/tests/snapshots/nodejs-docusaurus.txt
+++ b/tests/snapshots/nodejs-docusaurus.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "docusaurus"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "16"
+  nodeVersion: "23"
   outputDir: "build"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-expressjs.txt
+++ b/tests/snapshots/nodejs-expressjs.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "none"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/nodejs-foal.txt
+++ b/tests/snapshots/nodejs-foal.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "none"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "18"
+  nodeVersion: "23"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/nodejs-medusa-zb.txt
+++ b/tests/snapshots/nodejs-medusa-zb.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "medusa"
   initCmd: "RUN npm install -f -g yarn@latest"
   installCmd: "RUN yarn install"
-  nodeVersion: "20"
+  nodeVersion: "23"
   packageManager: "yarn"
   startCmd: "cd .medusa/server && yarn predeploy && yarn start"

--- a/tests/snapshots/nodejs-medusa.txt
+++ b/tests/snapshots/nodejs-medusa.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "medusa"
   initCmd: "RUN npm install -f -g yarn@latest"
   installCmd: "RUN yarn install"
-  nodeVersion: "20"
+  nodeVersion: "23"
   packageManager: "yarn"
   startCmd: "cd .medusa/server && yarn start"

--- a/tests/snapshots/nodejs-nestjs.txt
+++ b/tests/snapshots/nodejs-nestjs.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "nest.js"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/nodejs-nextjs.txt
+++ b/tests/snapshots/nodejs-nextjs.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "next.js"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "pnpm"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/nodejs-nuejs.txt
+++ b/tests/snapshots/nodejs-nuejs.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "nuejs"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/nodejs-nuxtjs.txt
+++ b/tests/snapshots/nodejs-nuxtjs.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "nuxt.js"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "pnpm"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/nodejs-payload.txt
+++ b/tests/snapshots/nodejs-payload.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "next.js"
   initCmd: "RUN npm install -f -g yarn@latest"
   installCmd: "RUN yarn install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "yarn"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/nodejs-qwik-city.txt
+++ b/tests/snapshots/nodejs-qwik-city.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "qwik"
   initCmd: "RUN npm update -g npm"
   installCmd: "RUN npm install"
-  nodeVersion: "15"
+  nodeVersion: "23"
   packageManager: "npm"
   startCmd: "npm run deploy"

--- a/tests/snapshots/nodejs-remix.txt
+++ b/tests/snapshots/nodejs-remix.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "remix"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "18"
+  nodeVersion: "23"
   packageManager: "pnpm"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/nodejs-rspress.txt
+++ b/tests/snapshots/nodejs-rspress.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "rspress"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   outputDir: "doc_build"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-slidev.txt
+++ b/tests/snapshots/nodejs-slidev.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "sli.dev"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   outputDir: "dist"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-starlight.txt
+++ b/tests/snapshots/nodejs-starlight.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "astro-starlight"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   outputDir: "dist"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-sveltekit-v2.txt
+++ b/tests/snapshots/nodejs-sveltekit-v2.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "svelte"
   initCmd: "RUN npm update -g npm"
   installCmd: "RUN npm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "npm"
   startCmd: "node build/index.js"

--- a/tests/snapshots/nodejs-umi.txt
+++ b/tests/snapshots/nodejs-umi.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "umi"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   outputDir: "dist"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-vite-vanilla.txt
+++ b/tests/snapshots/nodejs-vite-vanilla.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "vite"
   initCmd: "RUN npm install -f -g yarn@latest"
   installCmd: "RUN yarn install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   outputDir: "dist"
   packageManager: "unknown"
   serverless: "true"

--- a/tests/snapshots/nodejs-vitepress.txt
+++ b/tests/snapshots/nodejs-vitepress.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "vitepress"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   outputDir: "docs/.vitepress/dist"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-vocs.txt
+++ b/tests/snapshots/nodejs-vocs.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "vocs"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   outputDir: "docs/dist"
   packageManager: "pnpm"
   serverless: "true"

--- a/tests/snapshots/nodejs-waku.txt
+++ b/tests/snapshots/nodejs-waku.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "waku"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   packageManager: "pnpm"
   serverless: "true"
   startCmd: ""

--- a/tests/snapshots/static-hexo.txt
+++ b/tests/snapshots/static-hexo.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "hexo"
   initCmd: "RUN npm install -f -g yarn@latest"
   installCmd: "RUN yarn install"
-  nodeVersion: "20"
+  nodeVersion: "22"
   outputDir: "public"
   packageManager: "yarn"
   serverless: "true"


### PR DESCRIPTION
#### Description (required)

- **refactor(planner/nodejs): Update Node.js version**
- **feat(planner/nodejs): Implement getNodeVersion that only extracts major version**

#### Related issues & labels (optional)

- Closes ZEA-4591
- Suggested label: enhancement
