### PR TITLE
ZEA-4609: Merge Bun/Hono logic to Node.js planner

### DIFF
--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -35,11 +35,11 @@ schema = 3
     version = "v1.3.2"
     hash = "sha256-Qh2lAShlRm571xMxhAOfRoaFYzrfHmmk7RQmSiJxPbo="
   [mod."github.com/gkampitakis/go-snaps"]
-    version = "v0.5.10"
-    hash = "sha256-8lN/5584doDamZNiYe8UWIh2aMc8lJ0NH7JXJMaV0K8="
+    version = "v0.5.11"
+    hash = "sha256-ZSAqsHVVcrbu4BWgIoFigF8yOeI2w1lIdxgxMWrcwZo="
   [mod."github.com/goccy/go-yaml"]
-    version = "v1.15.19"
-    hash = "sha256-aDncy+24f167yD3q8aRBuwLufU4V+8cl3I9cGo4l24A="
+    version = "v1.15.23"
+    hash = "sha256-11AoZgodw3M2FSyu1UYL/RiGt2CfqHxX9JsRMmlDjXA="
   [mod."github.com/gogo/protobuf"]
     version = "v1.3.2"
     hash = "sha256-pogILFrrk+cAtb0ulqn9+gRZJ7sGnnLLdtqITvxvG6c="
@@ -143,11 +143,11 @@ schema = 3
     version = "v1.7.1"
     hash = "sha256-BjX0aY/PC37gIdMc7JhMgvhWFsksGdAcp2FgzpuvkPo="
   [mod."github.com/spf13/cobra"]
-    version = "v1.8.1"
-    hash = "sha256-yDF6yAHycV1IZOrt3/hofR+QINe+B2yqkcIaVov3Ky8="
+    version = "v1.9.1"
+    hash = "sha256-dzEqquABE3UqZmJuj99244QjvfojS8cFlsPr/MXQGj0="
   [mod."github.com/spf13/pflag"]
-    version = "v1.0.5"
-    hash = "sha256-w9LLYzxxP74WHT4ouBspH/iQZXjuAh2WQCHsuvyEjAw="
+    version = "v1.0.6"
+    hash = "sha256-NjrK0FZPIfO/p2xtL1J7fOBQNTZAPZOC6Cb4aMMvhxI="
   [mod."github.com/spf13/viper"]
     version = "v1.19.0"
     hash = "sha256-MZ8EAvdgpGbw6kmUz8UOaAAAMdPPGd14TrCBAY+A1T4="

--- a/internal/bun/bun.go
+++ b/internal/bun/bun.go
@@ -10,15 +10,6 @@ import (
 
 // GenerateDockerfile generates the Dockerfile for Bun projects.
 func GenerateDockerfile(meta types.PlanMeta) (string, error) {
-	if meta["framework"] == string(types.BunFrameworkHono) {
-		return `FROM oven/bun:` + meta["bunVersion"] + ` AS base
-WORKDIR /src
-COPY package.json bun.lock* ./
-RUN bun install
-COPY . .
-ENTRYPOINT [ "bun", "run", "` + meta["entry"] + `" ]`, nil
-	}
-
 	return nodejs.GenerateDockerfile(meta)
 }
 

--- a/internal/bun/plan.go
+++ b/internal/bun/plan.go
@@ -2,7 +2,6 @@ package bun
 
 import (
 	"log"
-	"strings"
 
 	"github.com/moznion/go-optional"
 	"github.com/spf13/afero"
@@ -36,15 +35,6 @@ func GetMeta(opt GetMetaOptions) types.PlanMeta {
 
 	bunVersion := DetermineVersion(ctx)
 	meta["bunVersion"] = bunVersion
-
-	if framework == types.BunFrameworkHono {
-		entry := determineEntry(ctx)
-		if entry != "" {
-			meta["entry"] = entry
-		}
-
-		return meta
-	}
 
 	if framework != types.BunFrameworkNone {
 		opt.BunFramework = optional.Some(framework)
@@ -99,29 +89,8 @@ func DetermineFramework(ctx *PlanContext) types.BunFramework {
 		return fw.Unwrap()
 	}
 
-	if _, isHono := packageJSON.Dependencies["hono"]; isHono {
-		*fw = optional.Some(types.BunFrameworkHono)
-		return fw.Unwrap()
-	}
-
 	*fw = optional.Some(types.BunFrameworkNone)
 	return fw.Unwrap()
-}
-
-func determineEntry(ctx *PlanContext) string {
-	if strings.HasPrefix(ctx.PackageJSON.Scripts["dev"], "bun run --hot") {
-		return strings.TrimPrefix(ctx.PackageJSON.Scripts["dev"], "bun run --hot ")
-	}
-
-	possibleEntries := []string{"index.ts", "index.js", "src/index.ts", "src/index.js"}
-
-	for _, entry := range possibleEntries {
-		if utils.HasFile(ctx.Src, entry) {
-			return entry
-		}
-	}
-
-	return ""
 }
 
 // DetermineVersion determines the Bun version to use.

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -849,12 +849,6 @@ func GetStartCmd(ctx *nodePlanContext) string {
 		return cmd.Unwrap()
 	}
 
-	// create-hono-app does not have "start" script by default.
-	if devScript := packageJSON.Scripts["dev"]; framework == types.NodeProjectFrameworkHono {
-		*cmd = optional.Some(devScript)
-		return cmd.Unwrap()
-	}
-
 	var startCmd string
 	runtime := lo.If(ctx.Bun, "bun").Else("node")
 
@@ -867,7 +861,13 @@ func GetStartCmd(ctx *nodePlanContext) string {
 		case types.IsNitroBasedFramework(string(framework)):
 			startCmd = "HOST=0.0.0.0 " + runtime + " .output/server/index.mjs"
 		default:
-			startCmd = runtime + " index.js"
+			if devScript := packageJSON.Scripts["dev"]; devScript != "" && framework == types.NodeProjectFrameworkHono {
+				// create-hono-app does not have "start" script by default.
+				startCmd = devScript
+			} else {
+				// fallback
+				startCmd = runtime + " index.js"
+			}
 		}
 	}
 

--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -849,10 +849,9 @@ func GetStartCmd(ctx *nodePlanContext) string {
 		return cmd.Unwrap()
 	}
 
-	// create-hono-app: bun run --hot <entrypoint>
-	if devScript := packageJSON.Scripts["dev"]; strings.HasPrefix(devScript, "bun run --hot") {
-		entry := strings.TrimSpace(strings.TrimPrefix(devScript, "bun run --hot"))
-		*cmd = optional.Some("bun " + entry)
+	// create-hono-app does not have "start" script by default.
+	if devScript := packageJSON.Scripts["dev"]; framework == types.NodeProjectFrameworkHono {
+		*cmd = optional.Some(devScript)
 		return cmd.Unwrap()
 	}
 

--- a/pkg/types/plan.go
+++ b/pkg/types/plan.go
@@ -92,6 +92,7 @@ const (
 	NodeProjectFrameworkGrammY           NodeProjectFramework = "grammy"
 	NodeProjectFrameworkNitropack        NodeProjectFramework = "nitropack"
 	NodeProjectFrameworkMedusa           NodeProjectFramework = "medusa"
+	NodeProjectFrameworkHono             NodeProjectFramework = "hono"
 )
 
 var NitroBasedFrameworks = []NodeProjectFramework{
@@ -244,6 +245,5 @@ const (
 	BunFrameworkElysia BunFramework = "elysia"
 	BunFrameworkBaojs  BunFramework = "baojs"
 	BunFrameworkBagel  BunFramework = "bagel"
-	BunFrameworkHono   BunFramework = "hono"
 	BunFrameworkNone   BunFramework = "none"
 )

--- a/tests/snapshots/bun-hono.txt
+++ b/tests/snapshots/bun-hono.txt
@@ -1,6 +1,13 @@
 PlanType: bun
 
 Meta:
+  appDir: ""
+  buildCmd: ""
+  bun: "true"
   bunVersion: "latest"
-  entry: "src/index.ts"
   framework: "hono"
+  initCmd: "RUN npm install -g bun@latest"
+  installCmd: "RUN bun install"
+  nodeVersion: "20"
+  packageManager: "bun"
+  startCmd: "bun run --hot src/index.ts"


### PR DESCRIPTION
#### Description (required)

- **chore: Update gomod2nix lockfile**
- **refactor(planner/bun): Merge Bun/hono logic to Node.js**
- **fix(planner/nodejs): Improve Hono support for Node.js**
- **test: Update snapshot**

#### Related issues & labels (optional)

- Closes ZEA-4609
- Suggested label: bug
