### PR TITLE
fix(planner/golang): Allow go.mod pointing to the local directory

### DIFF
--- a/internal/golang/golang.go
+++ b/internal/golang/golang.go
@@ -27,9 +27,8 @@ func GenerateDockerfile(meta types.PlanMeta) (string, error) {
 RUN mkdir /src
 WORKDIR /src
 ` + dependencySegment + `
-COPY go.mod go.sum* ./
-RUN go mod download
 COPY . /src/
+RUN go mod download
 ` + cgoEnvSegment + buildCommandSegment + `
 RUN go build -o ./bin/server ` + meta["entry"]
 


### PR DESCRIPTION
#### Description (required)

We COPY all the stuff first.

`go.mod` case:

```
// lib/leakless
replace github.com/ysmood/leakless => ./lib/leakless
```

#### Related issues & labels (optional)

- Closes ZEA-4659
- Suggested label: bug
