### PR TITLE
fix(planner/nodejs): vite can be in dependencies

### DIFF
--- a/internal/nodejs/plan.go
+++ b/internal/nodejs/plan.go
@@ -391,7 +391,7 @@ func DetermineAppFramework(ctx *nodePlanContext) types.NodeProjectFramework {
 		return fw.Unwrap()
 	}
 
-	if _, isVite := packageJSON.DevDependencies["vite"]; isVite {
+	if _, isVite := packageJSON.FindDependency("vite"); isVite {
 		*fw = optional.Some(types.NodeProjectFrameworkVite)
 		return fw.Unwrap()
 	}


### PR DESCRIPTION
#### Description (required)

See SUP-2010, npm changed the CI installation behavior.

#### Related issues & labels (optional)

- Closes ZEA-4828
- Suggested label: enhancement
