### PR TITLE
ZEA-5985: zbpack uses general Dockerfile instead of explicit-specified Dockerfile (xxx.Dockerfile)

### DIFF
--- a/internal/dockerfile/finder.go
+++ b/internal/dockerfile/finder.go
@@ -39,15 +39,7 @@ func FindDockerfile(ctx *FindContext) (filename string, err error) {
 
 	dockerfileName := plan.Cast(ctx.Config.Get(ConfigDockerfileName), cast.ToStringE).TakeOr(ctx.SubmoduleName)
 
-	// check if there is a 'Dockerfile' in the project.
-	dockerfileNames := []string{
-		"Dockerfile",
-	}
-	if dockerfileName != "" {
-		dockerfileNames = append(dockerfileNames, "Dockerfile."+dockerfileName)
-		dockerfileNames = append(dockerfileNames, dockerfileName+".Dockerfile")
-	}
-
+	// check if there is a 'Dockerfile.[project-name]' in the project.
 	fileInfo, err := afero.ReadDir(ctx.Source, ".")
 	if err != nil {
 		return "", fmt.Errorf("read dir: %w", err)
@@ -58,10 +50,18 @@ func FindDockerfile(ctx *FindContext) (filename string, err error) {
 			continue
 		}
 
-		for _, name := range dockerfileNames {
-			if strings.EqualFold(file.Name(), name) {
-				return file.Name(), nil
-			}
+		if strings.EqualFold(file.Name(), "Dockerfile."+dockerfileName) || strings.EqualFold(file.Name(), dockerfileName+".Dockerfile") {
+			return file.Name(), nil
+		}
+	}
+
+	// check if there is a 'Dockerfile' in the project.
+	for _, file := range fileInfo {
+		if file.IsDir() {
+			continue
+		}
+		if strings.EqualFold(file.Name(), "Dockerfile") {
+			return file.Name(), nil
 		}
 	}
 

--- a/internal/dockerfile/finder.go
+++ b/internal/dockerfile/finder.go
@@ -39,19 +39,21 @@ func FindDockerfile(ctx *FindContext) (filename string, err error) {
 
 	dockerfileName := plan.Cast(ctx.Config.Get(ConfigDockerfileName), cast.ToStringE).TakeOr(ctx.SubmoduleName)
 
-	// check if there is a 'Dockerfile.[project-name]' in the project.
 	fileInfo, err := afero.ReadDir(ctx.Source, ".")
 	if err != nil {
 		return "", fmt.Errorf("read dir: %w", err)
 	}
 
-	for _, file := range fileInfo {
-		if file.IsDir() {
-			continue
-		}
+	// check if there is a 'Dockerfile.[project-name]' in the project.
+	if dockerfileName != "" {
+		for _, file := range fileInfo {
+			if file.IsDir() {
+				continue
+			}
 
-		if strings.EqualFold(file.Name(), "Dockerfile."+dockerfileName) || strings.EqualFold(file.Name(), dockerfileName+".Dockerfile") {
-			return file.Name(), nil
+			if strings.EqualFold(file.Name(), "Dockerfile."+dockerfileName) || strings.EqualFold(file.Name(), dockerfileName+".Dockerfile") {
+				return file.Name(), nil
+			}
 		}
 	}
 

--- a/internal/dockerfile/finder_test.go
+++ b/internal/dockerfile/finder_test.go
@@ -193,3 +193,21 @@ func TestMatchDockerfileWithCustomPath(t *testing.T) {
 		assert.Empty(t, filename)
 	})
 }
+
+func TestMatchExplicitDockerfileInsteadOfGeneralOne(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	config := plan.NewProjectConfigurationFromFs(fs, "")
+	config.Set("dockerfile.name", "custom")
+
+	_ = afero.WriteFile(fs, "Dockerfile", []byte("FROM alpine"), 0o644)
+	_ = afero.WriteFile(fs, "Dockerfile.custom", []byte("FROM ubuntu"), 0o644)
+
+	filename, err := dockerfile.FindDockerfile(&dockerfile.FindContext{
+		Source: fs,
+		Config: config,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "Dockerfile.custom", filename)
+}

--- a/tests/snapshots/nodejs-docusaurus.txt
+++ b/tests/snapshots/nodejs-docusaurus.txt
@@ -7,7 +7,7 @@ Meta:
   framework: "docusaurus"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "23"
+  nodeVersion: "24"
   outputDir: "build"
   packageManager: "pnpm"
   startCmd: ""

--- a/tests/snapshots/nodejs-foal.txt
+++ b/tests/snapshots/nodejs-foal.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "none"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "23"
+  nodeVersion: "24"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/nodejs-medusa-zb.txt
+++ b/tests/snapshots/nodejs-medusa-zb.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "medusa"
   initCmd: "RUN npm install -f -g yarn@latest"
   installCmd: "RUN yarn install"
-  nodeVersion: "23"
+  nodeVersion: "24"
   packageManager: "yarn"
   startCmd: "cd .medusa/server && yarn predeploy && yarn start"

--- a/tests/snapshots/nodejs-medusa.txt
+++ b/tests/snapshots/nodejs-medusa.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "medusa"
   initCmd: "RUN npm install -f -g yarn@latest"
   installCmd: "RUN yarn install"
-  nodeVersion: "23"
+  nodeVersion: "24"
   packageManager: "yarn"
   startCmd: "cd .medusa/server && yarn start"

--- a/tests/snapshots/nodejs-qwik-city.txt
+++ b/tests/snapshots/nodejs-qwik-city.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "qwik"
   initCmd: "RUN npm update -g npm"
   installCmd: "RUN npm install"
-  nodeVersion: "23"
+  nodeVersion: "24"
   packageManager: "npm"
   startCmd: "npm run deploy"

--- a/tests/snapshots/nodejs-remix.txt
+++ b/tests/snapshots/nodejs-remix.txt
@@ -7,6 +7,6 @@ Meta:
   framework: "remix"
   initCmd: "RUN npm install -f -g pnpm@latest || npm install -f -g pnpm@8"
   installCmd: "RUN pnpm install"
-  nodeVersion: "23"
+  nodeVersion: "24"
   packageManager: "pnpm"
   startCmd: "pnpm start"

--- a/tests/snapshots/python-django-static-whitenoise.txt
+++ b/tests/snapshots/python-django-static-whitenoise.txt
@@ -6,7 +6,7 @@ Meta:
   framework: "django"
   install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
-  pythonVersion: "3.10"
+  pythonVersion: "3.13"
   start: "_startup() { gunicorn --bind :8080 core.wsgi; }; _startup"
   static-flag: "1"
   static-host-dir: ""

--- a/tests/snapshots/python-django-static.txt
+++ b/tests/snapshots/python-django-static.txt
@@ -6,7 +6,7 @@ Meta:
   framework: "django"
   install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
-  pythonVersion: "3.10"
+  pythonVersion: "3.13"
   start: "_startup() { /usr/sbin/nginx && gunicorn --bind :8000 core.wsgi; }; _startup"
   static-flag: "3"
   static-host-dir: "/app/staticfiles/"

--- a/tests/snapshots/python-django.txt
+++ b/tests/snapshots/python-django.txt
@@ -6,5 +6,5 @@ Meta:
   framework: "django"
   install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
-  pythonVersion: "3.10"
+  pythonVersion: "3.13"
   start: "_startup() { gunicorn --bind :8080 mysite.wsgi; }; _startup"

--- a/tests/snapshots/python-fastapi.txt
+++ b/tests/snapshots/python-fastapi.txt
@@ -6,5 +6,5 @@ Meta:
   framework: "fastapi"
   install: "RUN pip install uvicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
-  pythonVersion: "3.10"
+  pythonVersion: "3.13"
   start: "_startup() { uvicorn main:app --host 0.0.0.0 --port 8080; }; _startup"

--- a/tests/snapshots/python-flask-mysql.txt
+++ b/tests/snapshots/python-flask-mysql.txt
@@ -6,5 +6,5 @@ Meta:
   framework: "flask"
   install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
-  pythonVersion: "3.10"
+  pythonVersion: "3.13"
   start: "_startup() { gunicorn --bind :8080 app:app; }; _startup"

--- a/tests/snapshots/python-flask-static.txt
+++ b/tests/snapshots/python-flask-static.txt
@@ -6,5 +6,5 @@ Meta:
   framework: "flask"
   install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
-  pythonVersion: "3.10"
+  pythonVersion: "3.13"
   start: "_startup() { gunicorn --bind :8080 main:app; }; _startup"

--- a/tests/snapshots/python-flask.txt
+++ b/tests/snapshots/python-flask.txt
@@ -6,5 +6,5 @@ Meta:
   framework: "flask"
   install: "RUN pip install gunicorn\nRUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
-  pythonVersion: "3.10"
+  pythonVersion: "3.13"
   start: "_startup() { gunicorn --bind :8080 app:app; }; _startup"

--- a/tests/snapshots/python-streamlit.txt
+++ b/tests/snapshots/python-streamlit.txt
@@ -6,5 +6,5 @@ Meta:
   framework: "streamlit"
   install: "RUN sed '/-e/d' requirements.txt | pip install -r /dev/stdin"
   packageManager: "pip"
-  pythonVersion: "3.10"
+  pythonVersion: "3.13"
   start: "_startup() { streamlit run streamlit_app.py --server.port=8080 --server.address=0.0.0.0; }; _startup"


### PR DESCRIPTION
#### Description (required)

We search for `Dockerfile.[name]` and `[name].Dockerfile` first, then `Dockerfile`.

#### Related issues & labels (optional)

- Closes ZEA-5985
- Suggested label: bug
